### PR TITLE
Added simple lua example

### DIFF
--- a/examples/simple-example.lua
+++ b/examples/simple-example.lua
@@ -1,0 +1,29 @@
+local ffi = require("ffi")
+ffi.cdef[[
+    void *dlopen(const char *filename, int flags);
+]]
+ffi.C.dlopen("libgtk4-layer-shell.so", 0x101)
+local lgi = require("lgi")
+local Gtk = lgi.require("Gtk", "4.0")
+local layer_shell = lgi.require("Gtk4LayerShell")
+local app = Gtk.Application {
+   application_id = "com.github.a-cloud-ninja.gtk4-layer-shell.lua-example",
+}
+app.on_activate = function()
+   local win = Gtk.Window {
+      application = app
+   }
+   layer_shell.init_for_window(win)
+   layer_shell.set_layer(win, 2)
+   layer_shell.set_anchor(win, 1)
+   layer_shell.set_exclusive_zone(win, 0)
+   local button = Gtk.Button {
+      label = "Gtk4 Layer Shell Example",
+   }
+   button.on_clicked = function()
+      win:close()
+   end
+   win:set_child(button)
+   win:present()
+end
+app:run()


### PR DESCRIPTION
This adds an example for Lua which uses:
[ffi](https://luajit.org/ext_ffi.html) from [luajit](https://luajit.org/) to "preload" the library.
[lgi](https://github.com/lgi-devs/lgi) to *actually* load and use both gtk and gtk4-layer-shell.