### PR TITLE
Fix deprecation warning when running meson

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install depends
       run: sudo apt install meson libwayland-dev libgtk-4-dev gobject-introspection libgirepository1.0-dev valac gtk-doc-tools
     - name: Meson
-      run: meson build -Dexamples=true -Ddocs=true -Dtests=true
+      run: meson setup -Dexamples=true -Ddocs=true -Dtests=true build
       env:
         CFLAGS: -Werror
     - name: Build

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install depends
       run: sudo apt install meson libwayland-dev libgtk-4-dev gobject-introspection libgirepository1.0-dev valac gtk-doc-tools
     - name: Meson
-      run: meson build -Dexamples=false -Ddocs=true -Dtests=false --prefix $HOME
+      run: meson setup -Dexamples=false -Ddocs=true -Dtests=false --prefix $HOME build
     - name: Build Install
       run: ninja -C build install
     - name: Move files into place

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The easiest way to build against GTK Layer Shell is to use the `gtk-layer-shell-
 ## Building From Source
 1. Clone this repo
 2. Install build dependencies (see below)
-3. `$ meson build -Dexamples=true -Ddocs=true -Dtests=true`
+3. `$ meson setup -Dexamples=true -Ddocs=true -Dtests=true build`
 4. `$ ninja -C build`
 5. `$ sudo ninja -C build install`
 6. `$ sudo ldconfig`

--- a/examples/vala-standalone/README.md
+++ b/examples/vala-standalone/README.md
@@ -7,5 +7,5 @@ This is part of GTK4 Layer Shell, but is not built with the rest of the library.
 - [GTK4 Layer Shell](https://github.com/wmww/gtk4-layer-shell)
 
 ## Building
-- `meson build`
+- `meson setup build`
 - `ninja -C build`

--- a/test/tests-not-enabled.py
+++ b/test/tests-not-enabled.py
@@ -5,6 +5,6 @@ import sys
 
 color_green = '\x1b[32;1m'
 color_normal = '\x1b[0m'
-reconfig_command = color_green + 'meson build --reconfigure -Dtests=true' + color_normal
+reconfig_command = color_green + 'meson setup --reconfigure -Dtests=true build' + color_normal
 print('you must run ' + reconfig_command + ' in order to run the tests (where build is the path to your build directory)')
 exit(1)


### PR DESCRIPTION
If the commands from the README.md are followed, the following deprecation warning is displayed when running meson:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
This small change gets rid of it.