### PR TITLE
Finish gtk-layer-shell to gtk4-layer-shell renames

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -39,8 +39,8 @@ jobs:
       run: ninja -C build install
     - name: Move files into place
       run: |
-        mv $HOME/share/gtk-doc/html/gtk-layer-shell ./_site
-        cp ./_site/gtk-layer-shell-GTK4-Layer-Shell.html ./_site/index.html
+        mv $HOME/share/gtk-doc/html/gtk4-layer-shell ./_site
+        cp ./_site/gtk4-layer-shell-GTK4-Layer-Shell.html ./_site/index.html
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
 

--- a/doc/gtk4-layer-shell-docs.sgml
+++ b/doc/gtk4-layer-shell-docs.sgml
@@ -60,7 +60,7 @@
     <title>API Reference</title>
     <partintro>
       <para>
-        Gtk-layer-shell is a library to write <ulink type ="http" url="https://www.gtk.org/">GTK</ulink>
+        gtk4-layer-shell is a library to write <ulink type ="http" url="https://www.gtk.org/">GTK</ulink>
          applications that use <ulink type="https" url="https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-layer-shell-unstable-v1.xml">Layer Shell</ulink>.
          Layer Shell is a Wayland protocol for desktop shell components,
          such as panels, notifications and wallpapers. You can use it to anchor

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -5,8 +5,8 @@ glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 docpath = join_paths(get_option('datadir'), 'gtk-doc', 'html')
 
 gnome.gtkdoc(
-    'gtk-layer-shell',
-    main_xml: 'gtk-layer-shell-docs.sgml',
+    'gtk4-layer-shell',
+    main_xml: 'gtk4-layer-shell-docs.sgml',
     src_dir: [
         join_paths(meson.source_root(), 'include'),
         join_paths(meson.build_root(), 'include'),
@@ -19,6 +19,6 @@ gnome.gtkdoc(
         '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gio')),
         '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gtk3')),
     ],
-    install_dir: 'gtk-layer-shell',
+    install_dir: 'gtk4-layer-shell',
     install: true
 )

--- a/examples/demo/gtk-layer-demo.c
+++ b/examples/demo/gtk-layer-demo.c
@@ -96,7 +96,7 @@ static const GOptionEntry options[] = {
         .flags = G_OPTION_FLAG_NONE,
         .arg = G_OPTION_ARG_NONE,
         .arg_data = &no_layer_shell,
-        .description = "Disable gtk-layer-shell, create a normal shell surface instead",
+        .description = "Disable gtk4-layer-shell, create a normal shell surface instead",
         .arg_description = NULL,
     },
     { NULL, 0, 0, 0, NULL, NULL, NULL }
@@ -250,7 +250,7 @@ process_args (int *argc, char ***argv)
     if (show_version_and_exit)
     {
         g_print (
-            "%s on gtk-layer-shell v%d.%d.%d\n",
+            "%s on gtk4-layer-shell v%d.%d.%d\n",
             prog_name,
             gtk_layer_get_major_version (),
             gtk_layer_get_minor_version (),

--- a/examples/vala-standalone/meson.build
+++ b/examples/vala-standalone/meson.build
@@ -1,4 +1,4 @@
-project('vala-gtk-layer-shell-example',
+project('vala-gtk4-layer-shell-example',
     ['vala', 'c'],
     version: '0.1.0',
     license: 'MIT',

--- a/include/gtk4-layer-shell.h
+++ b/include/gtk4-layer-shell.h
@@ -154,7 +154,7 @@ struct zwlr_layer_surface_v1 *gtk_layer_get_zwlr_layer_surface_v1 (GtkWindow *wi
  * ownership of original. If the window is currently mapped, it will get remapped so
  * the change can take effect.
  *
- * Default is "gtk-layer-shell" (which will be used if set to %NULL)
+ * Default is "gtk4-layer-shell" (which will be used if set to %NULL)
  */
 void gtk_layer_set_namespace (GtkWindow *window, char const* name_space);
 
@@ -166,7 +166,7 @@ void gtk_layer_set_namespace (GtkWindow *window, char const* name_space);
  * Future calls into the library may invalidate the returned string.
  *
  * Returns: a reference to the namespace property. If namespace is unset, returns the
- * default namespace ("gtk-layer-shell"). Never returns %NULL.
+ * default namespace ("gtk4-layer-shell"). Never returns %NULL.
  */
 const char *gtk_layer_get_namespace (GtkWindow *window);
 
@@ -290,7 +290,7 @@ int gtk_layer_get_exclusive_zone (GtkWindow *window);
  * exclusive zone to 0 or any other fixed value.
  *
  * NOTE: you can control the auto exclusive zone by changing the margin on the non-anchored
- * edge. This behavior is specific to gtk-layer-shell and not part of the underlying protocol
+ * edge. This behavior is specific to gtk4-layer-shell and not part of the underlying protocol
  */
 void gtk_layer_auto_exclusive_zone_enable (GtkWindow *window);
 

--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -469,7 +469,7 @@ layer_surface_get_namespace (LayerSurface *self)
     if (self && self->name_space)
         return self->name_space;
     else
-        return "gtk-layer-shell";
+        return "gtk4-layer-shell";
 }
 
 static void

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 # GTK Layer Shell tests
-This directory is home to the gtk-layer-shell test suite.
+This directory is home to the gtk4-layer-shell test suite.
 
 ## To run tests
 `ninja -C build test` (where `build` is the path to your build directory).

--- a/test/integration-tests/test-get-namespace-default.c
+++ b/test/integration-tests/test-get-namespace-default.c
@@ -8,7 +8,7 @@ static void callback_0()
     gtk_layer_init_for_window(window);
     gtk_window_present(window);
     const char *name_space = gtk_layer_get_namespace(window);
-    ASSERT_STR_EQ(name_space, "gtk-layer-shell");
+    ASSERT_STR_EQ(name_space, "gtk4-layer-shell");
 }
 
 TEST_CALLBACKS(

--- a/test/integration-tests/test-get-namespace-on-non-layer-window.c
+++ b/test/integration-tests/test-get-namespace-on-non-layer-window.c
@@ -6,7 +6,7 @@ static void callback_0()
 {
     window = create_default_window();
     const char *name_space = gtk_layer_get_namespace(window);
-    ASSERT_STR_EQ(name_space, "gtk-layer-shell");
+    ASSERT_STR_EQ(name_space, "gtk4-layer-shell");
 }
 
 TEST_CALLBACKS(


### PR DESCRIPTION
If there's going to be a separate repository for the gtk4 variant, then it would be nice if both gtk-layer-shell and gtk4-layer-shell could co-exist.

Fixes #13