### PR TITLE
Remove proxies from libwayland list when destroying them

### DIFF
--- a/src/libwayland-shim.c
+++ b/src/libwayland-shim.c
@@ -197,6 +197,7 @@ wl_proxy_destroy (struct wl_proxy *proxy)
         if (wrapper->destroy) {
             wrapper->destroy(wrapper->data, proxy);
         }
+        wl_list_remove(&proxy->queue_link);
         // No need to worry about the refcount since it's only accessibly within libwayland, and it's only used by
         // functions that never see client facing objects
         g_free (proxy);


### PR DESCRIPTION
I believe this fixes #24 (though I was unable to reproduce it). It definitely fixes crashes I was getting messing with the tests. 

`proxy->queue_link` was not being removed from libwayland's list, and so libwayland was accessing the freed memory later when new members were added or removed from the list. Annoyingly instead of segfaulting there, the pattern seems to be that a new allocation has already been made in GTK on the same memory, and it only crashes once GTK tries to use the trampled structure. Don't ask me how long it took me in rr to figure that out. 