### PR TITLE
Fix tests on Arch

### DIFF
--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -24,8 +24,8 @@ gtk_window_get_layer_surface (GtkWindow *gtk_window)
 static void
 layer_surface_remap (LayerSurface *self)
 {
-    gtk_widget_set_visible (GTK_WIDGET (self->gtk_window), FALSE);
-    gtk_widget_set_visible (GTK_WIDGET (self->gtk_window), TRUE);
+    gtk_widget_unrealize (GTK_WIDGET (self->gtk_window));
+    gtk_widget_map (GTK_WIDGET (self->gtk_window));
 }
 
 static void

--- a/test/mock-server/overrides.c
+++ b/test/mock-server/overrides.c
@@ -35,7 +35,9 @@ static uint32_t click_serial = 0;
 // Needs to be called before any role objects are assigned
 static void surface_data_set_role(SurfaceData* data, SurfaceRole role)
 {
-    ASSERT_EQ(data->role, SURFACE_ROLE_NONE, "%u");
+    if (data->role != SURFACE_ROLE_NONE) {
+        ASSERT_EQ(data->role, role, "%u");
+    }
     char is_xdg_role = (role == SURFACE_ROLE_XDG_TOPLEVEL || role == SURFACE_ROLE_XDG_POPUP);
     ASSERT_EQ(data->xdg_surface != NULL, is_xdg_role, "%d");
     ASSERT(!data->xdg_toplevel);


### PR DESCRIPTION
Some tests have broken on Arch (even though they still work on the Ubuntu used by CI). This should make them work on both.