### PR TITLE
Make tests compatible with new libwayland format

### DIFF
--- a/test/integration-tests/test-set-monitor.c
+++ b/test/integration-tests/test-set-monitor.c
@@ -4,7 +4,7 @@ static GtkWindow* window;
 
 static void callback_0()
 {
-    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output@);
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output);
     window = create_default_window();
     gtk_layer_init_for_window(window);
     ASSERT_EQ(g_list_model_get_n_items(gdk_display_get_monitors(gdk_display_get_default())), 1, "%d");

--- a/test/run-integration-test.py
+++ b/test/run-integration-test.py
@@ -224,7 +224,7 @@ def verify_result(lines: List[str]):
         elif line.startswith('DONT_EXPECT: '):
             negative_assertions.append(line.split()[1:])
             set_expectation = True
-        elif line.startswith('[') and line.endswith(')') and '@' in line:
+        elif line.startswith('[') and line.endswith(')') and ('@' in line or '#' in line):
             if assertions and line_contains(line, assertions[0]):
                 assertions = assertions[1:]
             for negative_assertion in negative_assertions:


### PR DESCRIPTION
Fixes #41, matches GTK3 version [here](https://github.com/wmww/gtk-layer-shell/pull/188)