### PR TITLE
Fix protocol error caused by sending xdg_shell configure events too early

### DIFF
--- a/src/layer-surface.h
+++ b/src/layer-surface.h
@@ -39,6 +39,7 @@ struct _LayerSurface
       // GTK can be ignored (they are for configures not originating from the compositor)
     struct xdg_surface *client_facing_xdg_surface;
     struct xdg_toplevel *client_facing_xdg_toplevel;
+    bool has_initial_layer_shell_configure;
 };
 
 LayerSurface *layer_surface_new (GtkWindow *gtk_window);


### PR DESCRIPTION
This PR fixes #34.

Sending xdg_toplevel->configure and xdg_surface->configure before receiving zwlr_layer_shell_surface_v1->configure causes GTK to think the surface is already configured and can result in GTK attaching a buffer too early. This causes a protocol error as buffers can only be attached to surfaces that have been configured.

See more in the discussion of the linked issue.