### PR TITLE
Implement session lock protocol

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -14,6 +14,13 @@ executable(
     dependencies: [gtk, gtk_layer_shell],
     install: false)
 
+executable(
+    'session-lock-c',
+    files('session-lock.c'),
+    build_by_default: get_option('examples'),
+    dependencies: [gtk, gtk_layer_shell],
+    install: false)
+
 if get_option('vapi')
     add_languages('vala')
     executable(

--- a/examples/session-lock.c
+++ b/examples/session-lock.c
@@ -1,0 +1,93 @@
+#include "gtk4-layer-shell.h"
+#include <gtk/gtk.h>
+
+typedef struct {
+    GtkApplication *app;
+    GtkLayerShellSessionLock *session_lock;
+} AppData;
+
+static void
+unlock (GtkButton *button, void *data)
+{
+    (void)button;
+    AppData *app_data = (AppData *)data;
+
+    gtk_layer_session_lock_unlock_and_destroy (app_data->session_lock);
+    gdk_display_sync (gdk_display_get_default ());
+
+    g_application_quit (G_APPLICATION (app_data->app));
+}
+
+static void
+locked (GtkLayerShellSessionLock *session_lock, void *data)
+{
+    (void)data;
+    (void)session_lock;
+    g_print ("Session locked successfully\n");
+}
+
+static void
+finished (GtkLayerShellSessionLock *session_lock, void *data)
+{
+    (void)data;
+    (void)session_lock;
+    g_critical ("Received finish signal, the session could not be locked\n");
+}
+
+static void
+activate (GtkApplication* app, void *data)
+{
+    (void)data;
+    g_application_hold (G_APPLICATION (app));
+
+    GtkLayerShellSessionLock *session_lock = gtk_layer_session_lock_new ();
+    gtk_layer_session_lock_lock (session_lock);
+
+    GdkDisplay *display = gdk_display_get_default ();
+    GListModel *monitors = gdk_display_get_monitors (display);
+    guint n_monitors = g_list_model_get_n_items (monitors);
+
+    AppData *app_data = g_new0 (AppData, 1);
+    app_data->app = app;
+    app_data->session_lock = session_lock;
+
+    g_object_set_data_full (G_OBJECT (app),
+                            "app-data",
+                            app_data,
+                            (GDestroyNotify)g_free);
+
+    g_signal_connect (session_lock, "locked", G_CALLBACK (locked), NULL);
+    g_signal_connect (session_lock, "finished", G_CALLBACK (finished), NULL);
+
+    for (guint i = 0; i < n_monitors; ++i) {
+        GdkMonitor *monitor = g_list_model_get_item (monitors, i);
+
+        GtkWindow *gtk_window = GTK_WINDOW (gtk_application_window_new (app));
+        gtk_layer_session_lock_create_surface_for_window (session_lock, gtk_window, monitor);
+
+        GtkWidget *box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+        gtk_widget_set_halign (box, GTK_ALIGN_CENTER);
+        gtk_widget_set_valign (box, GTK_ALIGN_CENTER);
+        gtk_box_set_spacing (GTK_BOX (box), 10);
+
+        GtkWidget *label = gtk_label_new ("GTK Session Lock example");
+        gtk_box_append (GTK_BOX (box), label);
+
+        GtkWidget *button = gtk_button_new_with_label ("Unlock");
+        g_signal_connect (button, "clicked", G_CALLBACK (unlock), app_data);
+        gtk_box_append (GTK_BOX (box), button);
+
+        gtk_window_set_child (GTK_WINDOW (gtk_window), box);
+        gtk_window_present (gtk_window);
+    }
+}
+
+int
+main (int argc, char **argv)
+{
+    GtkApplication *app = gtk_application_new ("com.github.wmww.gtk4-layer-shell.session-lock-example", G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect (app, "activate", G_CALLBACK (activate), NULL);
+    int status = g_application_run (G_APPLICATION (app), argc, argv);
+    g_object_unref (app);
+    return status;
+}

--- a/include/gtk4-layer-shell.h
+++ b/include/gtk4-layer-shell.h
@@ -322,6 +322,28 @@ void gtk_layer_set_keyboard_mode (GtkWindow *window, GtkLayerShellKeyboardMode m
  */
 GtkLayerShellKeyboardMode gtk_layer_get_keyboard_mode (GtkWindow *window);
 
+G_DECLARE_FINAL_TYPE(GtkLayerShellSessionLock, gtk_layer_session_lock, GTK_LAYER_SESSION_LOCK, SESSION_LOCK, GObject)
+
+GtkLayerShellSessionLock * gtk_layer_session_lock_new ();
+
+void gtk_layer_session_lock_lock (GtkLayerShellSessionLock *self);
+
+void gtk_layer_session_lock_destroy (GtkLayerShellSessionLock *self);
+
+void gtk_layer_session_lock_unlock_and_destroy (GtkLayerShellSessionLock *self);
+
+void gtk_layer_session_lock_create_surface_for_window (GtkLayerShellSessionLock *self, GtkWindow *gtk_window, GdkMonitor *gdk_monitor);
+
+/**
+ * gtk_layer_session_lock_is_supported:
+ *
+ * May block for a Wayland roundtrip the first time it's called.
+ *
+ * Returns: %TRUE if the platform is Wayland and Wayland compositor supports the
+ * ext_session_lock_v1 protocol.
+ */
+gboolean gtk_layer_session_lock_is_supported ();
+
 G_END_DECLS
 
 #endif // GTK_LAYER_SHELL_H

--- a/protocol/ext-session-lock-v1.xml
+++ b/protocol/ext-session-lock-v1.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_session_lock_v1">
+  <copyright>
+    Copyright 2021 Isaac Freund
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  </copyright>
+
+  <description summary="secure session locking with arbitrary graphics">
+    This protocol allows for a privileged Wayland client to lock the session
+    and display arbitrary graphics while the session is locked.
+
+    The compositor may choose to restrict this protocol to a special client
+    launched by the compositor itself or expose it to all privileged clients,
+    this is compositor policy.
+
+    The client is responsible for performing authentication and informing the
+    compositor when the session should be unlocked. If the client dies while
+    the session is locked the session remains locked, possibly permanently
+    depending on compositor policy.
+
+    Warning! The protocol described in this file is currently in the
+    testing phase. Backward compatible changes may be added together with
+    the corresponding interface version bump. Backward incompatible changes
+    can only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_session_lock_manager_v1" version="1">
+    <description summary="used to lock the session">
+      This interface is used to request that the session be locked.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the session lock manager object">
+        This informs the compositor that the session lock manager object will
+        no longer be used. Existing objects created through this interface
+        remain valid.
+      </description>
+    </request>
+
+    <request name="lock">
+      <description summary="attempt to lock the session">
+        This request creates a session lock and asks the compositor to lock the
+        session. The compositor will send either the ext_session_lock_v1.locked
+        or ext_session_lock_v1.finished event on the created object in
+        response to this request.
+      </description>
+      <arg name="id" type="new_id" interface="ext_session_lock_v1"/>
+    </request>
+  </interface>
+
+  <interface name="ext_session_lock_v1" version="1">
+    <description summary="manage lock state and create lock surfaces">
+      On creation of this object either the locked or finished event will
+      immediately be sent.
+
+      The locked event indicates that the session is locked. This means that
+      the compositor should stop rendering and providing input to normal
+      clients. Instead the compositor should blank all outputs with an opaque
+      color such that their normal content is fully hidden.
+
+      The only surfaces that should be rendered while the session is locked
+      are the lock surfaces created through this interface and optionally,
+      at the compositor's discretion, special privileged surfaces such as
+      input methods or portions of desktop shell UIs.
+
+      If the client dies while the session is locked, the compositor should not
+      unlock the session in response. It is acceptable for the session to be
+      permanently locked if this happens. The compositor may choose to continue
+      to display the lock surfaces the client had mapped before it died or
+      alternatively fall back to a solid color, this is compositor policy.
+
+      Compositors may also allow a secure way to recover the session, the
+      details of this are compositor policy. Compositors may allow a new
+      client to create a ext_session_lock_v1 object and take responsibility
+      for unlocking the session, they may even start a new lock client
+      instance automatically.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_destroy" value="0"
+        summary="attempted to destroy session lock while locked"/>
+      <entry name="invalid_unlock" value="1"
+        summary="unlock requested but locked event was never sent"/>
+      <entry name="role" value="2"
+        summary="given wl_surface already has a role"/>
+      <entry name="duplicate_output" value="3"
+        summary="given output already has a lock surface"/>
+      <entry name="already_constructed" value="4"
+        summary="given wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the session lock">
+        This informs the compositor that the lock object will no longer be
+        used. Existing objects created through this interface remain valid.
+
+        After this request is made, lock surfaces created through this object
+        should be destroyed by the client as they will no longer be used by
+        the compositor.
+
+        It is a protocol error to make this request if the locked event was
+        sent, the unlock_and_destroy request must be used instead.
+      </description>
+    </request>
+
+    <event name="locked">
+      <description summary="session successfully locked">
+        This client is now responsible for displaying graphics while the
+        session is locked and deciding when to unlock the session.
+
+        Either this event or the finished event will be sent immediately on
+        creation of this object.
+
+        If this event is sent, making the destroy request is a protocol error,
+        the lock object may only be destroyed using the unlock_and_destroy
+        request.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the session lock object should be destroyed">
+        The compositor has decided that the session lock should be
+        destroyed. Exactly when this event is sent is compositor policy, but
+        it will never be sent more than once for a given session lock object.
+
+        This might be sent because there is already another ext_session_lock_v1
+        object held by a client, or the compositor has decided to deny the
+        request to lock the session for some other reason. This might also
+        be sent because the compositor implements some alternative, secure
+        way to authenticate and unlock the session.
+
+        Either this event or the locked event will be sent exactly once on
+        creation of this object. If the locked event is sent on creation of
+        this object, the finished event may still be sent at some later time
+        in this object's lifetime, this is compositor policy.
+
+        Upon receiving this event, the client should make either the destroy
+        request or the unlock_and_destroy request, depending on whether or
+        not the locked event was received on this object.
+      </description>
+    </event>
+
+    <request name="get_lock_surface">
+      <description summary="create a lock surface for a given output">
+        The client is expected to create lock surfaces for all outputs
+        currently present and any new outputs as they are advertised. These
+        won't be displayed by the compositor unless the lock is successful
+        and the locked event is sent.
+
+        Providing a wl_surface which already has a role or already has a buffer
+        attached or committed is a protocol error, as is attaching/committing
+        a buffer before the first ext_session_lock_surface_v1.configure event.
+
+        Attempting to create more than one lock surface for a given output
+        is a duplicate_output protocol error.
+      </description>
+      <arg name="id" type="new_id" interface="ext_session_lock_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="unlock_and_destroy" type="destructor">
+      <description summary="unlock the session, destroying the object">
+        This request indicates that the session should be unlocked, for
+        example because the user has entered their password and it has been
+        verified by the client.
+
+        This request also informs the compositor that the lock object will
+        no longer be used and may be safely destroyed. Existing objects
+        created through this interface remain valid.
+
+        After this request is made, lock surfaces created through this object
+        should be destroyed by the client as they will no longer be used by
+        the compositor.
+
+        It is a protocol error to make this request if the locked event has
+        not been sent. In that case, the lock object may only be destroyed
+        using the destroy request.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_session_lock_surface_v1" version="1">
+    <description summary="a surface displayed while the session is locked">
+      The client may use lock surfaces to display a screensaver, render a
+      dialog to enter a password and unlock the session, or however else it
+      sees fit.
+
+      On binding this interface the compositor will immediately send the
+      first configure event. After making the ack_configure request in
+      response to this event the client may attach and commit the first
+      buffer. Committing the surface before acking the first configure is a
+      protocol error. Committing the surface with a null buffer at any time
+      is a protocol error.
+
+      The compositor is free to handle keyboard/pointer focus for lock
+      surfaces however it chooses. A reasonable way to do this would be to
+      give the first lock surface created keyboard focus and change keyboard
+      focus if the user clicks on other surfaces.
+    </description>
+
+    <enum name="error">
+      <entry name="commit_before_first_ack" value="0"
+        summary="surface committed before first ack_configure request"/>
+      <entry name="null_buffer" value="1"
+        summary="surface committed with a null buffer"/>
+      <entry name="dimensions_mismatch" value="2"
+        summary="failed to match ack'd width/height"/>
+      <entry name="invalid_serial" value="3"
+        summary="serial provided in ack_configure is invalid"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the lock surface object">
+        This informs the compositor that the lock surface object will no
+        longer be used.
+
+        It is recommended for a lock client to destroy lock surfaces if
+        their corresponding wl_output global is removed.
+
+        If a lock surface on an active output is destroyed before the
+        ext_session_lock_v1.unlock_and_destroy event is sent, the compositor
+        must fall back to rendering a solid color.
+      </description>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the surface
+        in response to the configure event, then the client must make an
+        ack_configure request sometime before the commit request, passing
+        along the serial of the configure event.
+
+        If the client receives multiple configure events before it can
+        respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending an
+        ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing,
+        but only the last request sent before a commit indicates which
+        configure event the client really is responding to.
+
+        Sending an ack_configure request consumes the configure event
+        referenced by the given serial, as well as all older configure events
+        sent on this object.
+
+        It is a protocol error to issue multiple ack_configure requests
+        referencing the same configure event or to issue an ack_configure
+        request referencing a configure event older than the last configure
+        event acked for a given lock surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial from the configure event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="the client should resize its surface">
+        This event is sent once on binding the interface and may be sent again
+        at the compositor's discretion, for example if output geometry changes.
+
+        The width and height are in surface-local coordinates and are exact
+        requirements. Failing to match these surface dimensions in the next
+        commit after acking a configure is a protocol error.
+      </description>
+      <arg name="serial" type="uint" summary="serial for use in ack_configure"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+  </interface>
+</protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -6,6 +6,7 @@ endif
 
 protocols = [
     'wlr-layer-shell-unstable-v1.xml',
+    'ext-session-lock-v1.xml',
     join_paths(
         wayland_protocols.get_variable(pkgconfig: 'pkgdatadir'),
         'stable/xdg-shell/xdg-shell.xml'),

--- a/src/api.c
+++ b/src/api.c
@@ -1,5 +1,6 @@
 #include "wayland-utils.h"
 #include "layer-surface.h"
+#include "session-lock.h"
 #include "libwayland-shim.h"
 
 #include <gdk/wayland/gdkwayland.h>
@@ -202,4 +203,43 @@ gtk_layer_get_keyboard_mode (GtkWindow *window)
     LayerSurface *layer_surface = gtk_window_get_layer_surface_or_warn (window);
     if (!layer_surface) return GTK_LAYER_SHELL_KEYBOARD_MODE_NONE;
     return layer_surface->keyboard_mode;
+}
+
+
+GtkLayerShellSessionLock *
+gtk_layer_session_lock_new ()
+{
+    gtk_wayland_init_if_needed ();
+    return g_object_new (gtk_layer_session_lock_get_type (), NULL);
+}
+
+void
+gtk_layer_session_lock_lock (GtkLayerShellSessionLock *self)
+{
+    session_lock_lock (self);
+}
+
+void
+gtk_layer_session_lock_destroy (GtkLayerShellSessionLock *self)
+{
+    session_lock_destroy (self);
+}
+
+void
+gtk_layer_session_lock_unlock_and_destroy (GtkLayerShellSessionLock *self)
+{
+    session_lock_unlock_and_destroy (self);
+}
+
+void
+gtk_layer_session_lock_create_surface_for_window (GtkLayerShellSessionLock *self, GtkWindow *gtk_window, GdkMonitor *gdk_monitor)
+{
+    session_lock_create_surface_for_window (self, gtk_window, gdk_monitor);
+}
+
+gboolean
+gtk_layer_session_lock_is_supported ()
+{
+    gtk_wayland_init_if_needed ();
+    return libwayland_shim_has_initialized () && gtk_wayland_get_session_lock_manager_global () != NULL;
 }

--- a/src/libwayland-shim.c
+++ b/src/libwayland-shim.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "libwayland-shim.h"
 #include "layer-surface.h"
+#include "session-lock.h"
 #include "wayland-utils.h"
 
 struct wl_proxy *(*libwayland_shim_real_wl_proxy_marshal_array_flags) (
@@ -285,7 +286,10 @@ wl_proxy_marshal_array_flags (
     } else {
         struct wl_proxy *ret_proxy = NULL;
         if (layer_surface_handle_request (proxy, opcode, interface, version, flags, args, &ret_proxy)) {
-            // The behavior of the request has been overridden
+            // The behavior of the request has been overridden by a layer surface
+            return ret_proxy;
+        } else if (session_lock_surface_handle_request (proxy, opcode, interface, version, flags, args, &ret_proxy)) {
+            // The behavior of the request has been overridden by a session lock surface
             return ret_proxy;
         } else if (args_contains_client_facing_proxy (proxy, opcode, interface, args)) {
             // We can't do the normal thing because one of the arguments is an object libwayand doesn't know about, but

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ srcs = files(
     'api.c',
     'libwayland-shim.c',
     'layer-surface.c',
+    'session-lock.c',
     'wayland-utils.c')
 
 version_args = [

--- a/src/session-lock.c
+++ b/src/session-lock.c
@@ -1,0 +1,368 @@
+#include "session-lock.h"
+
+#include "wayland-utils.h"
+#include "libwayland-shim.h"
+
+#include "ext-session-lock-v1-client.h"
+#include "xdg-shell-client.h"
+
+#include <gtk/gtk.h>
+#include <gdk/wayland/gdkwayland.h>
+
+static const char *lock_surface_key = "wayland_lock_surface";
+GList* all_lock_surfaces = NULL;
+
+struct _GtkLayerShellSessionLock
+{
+    GObject parent_instance;
+};
+
+typedef struct {
+    struct ext_session_lock_v1 *lock;
+} GtkLayerShellSessionLockPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (GtkLayerShellSessionLock, gtk_layer_session_lock, G_TYPE_OBJECT)
+
+static void
+gtk_layer_session_lock_init (GtkLayerShellSessionLock *self)
+{
+    if (!GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ())) {
+        g_warning ("Failed to initialize session lock, not on Wayland");
+        return;
+    }
+
+    if (!libwayland_shim_has_initialized ()) {
+        g_warning ("Failed to initialize session lock, GTK4 Layer Shell may have been linked after libwayland.");
+        g_message ("Move gtk4-layer-shell before libwayland-client in the linker options.");
+        g_message ("You may be able to fix with without recompiling by setting LD_PRELOAD=/path/to/libgtk4-layer-shell.so");
+        g_message ("See https://github.com/wmww/gtk4-layer-shell/blob/main/linking.md for more info");
+        return;
+    }
+
+    if (!gtk_wayland_get_session_lock_manager_global ()) {
+        g_warning ("Failed to initialize session lock, it appears your Wayland compositor doesn't support the session lock protocol");
+        return;
+    }
+
+    GtkLayerShellSessionLockPrivate *priv = gtk_layer_session_lock_get_instance_private (self);
+    g_return_if_fail (priv);
+}
+
+enum {
+    SESSION_LOCK_SIGNAL_LOCKED = 1,
+    SESSION_LOCK_SIGNAL_FINISHED,
+    SESSION_LOCK_SIGNAL_LAST
+};
+
+static guint session_lock_signals[SESSION_LOCK_SIGNAL_LAST] = { 0, };
+
+static void
+gtk_layer_session_lock_class_init (GtkLayerShellSessionLockClass *cclass)
+{
+    session_lock_signals[SESSION_LOCK_SIGNAL_LOCKED] = g_signal_new (
+        "locked",
+        G_TYPE_FROM_CLASS (cclass),
+        G_SIGNAL_RUN_FIRST,
+        0,
+        NULL,
+        NULL,
+        NULL,
+        G_TYPE_NONE,
+        0
+    );
+
+    session_lock_signals[SESSION_LOCK_SIGNAL_FINISHED] = g_signal_new (
+        "finished",
+        G_TYPE_FROM_CLASS (cclass),
+        G_SIGNAL_RUN_FIRST,
+        0,
+        NULL,
+        NULL,
+        NULL,
+        G_TYPE_NONE,
+        0
+    );
+}
+
+static void
+session_lock_handle_locked (void *data,
+                            struct ext_session_lock_v1 *manager)
+{
+    (void)manager;
+    GtkLayerShellSessionLock *self = (GtkLayerShellSessionLock *)data;
+    g_signal_emit (self, session_lock_signals[SESSION_LOCK_SIGNAL_LOCKED], 0);
+}
+
+static void
+session_lock_handle_finished (void *data,
+                              struct ext_session_lock_v1 *manager)
+{
+    (void)manager;
+    GtkLayerShellSessionLock *self = (GtkLayerShellSessionLock *)data;
+    g_signal_emit (self, session_lock_signals[SESSION_LOCK_SIGNAL_FINISHED], 0);
+}
+
+static void
+session_lock_surface_unmap (SessionLockSurface *self)
+{
+    if (self->lock_surface) {
+        ext_session_lock_surface_v1_destroy (self->lock_surface);
+        self->lock_surface = NULL;
+    }
+
+    libwayland_shim_clear_client_proxy_data((struct wl_proxy *)self->client_facing_xdg_surface);
+    libwayland_shim_clear_client_proxy_data((struct wl_proxy *)self->client_facing_xdg_toplevel);
+
+    self->client_facing_xdg_surface = NULL;
+    self->client_facing_xdg_toplevel = NULL;
+    self->can_commit = false;
+}
+
+static void
+session_lock_surface_destroy (SessionLockSurface *self)
+{
+    session_lock_surface_unmap (self);
+    all_lock_surfaces = g_list_remove (all_lock_surfaces, self);
+    g_free (self);
+}
+
+static void
+session_lock_surface_handle_configure (void *data,
+                                       struct ext_session_lock_surface_v1 *surface,
+                                       uint32_t serial,
+                                       uint32_t width,
+                                       uint32_t height)
+{
+    (void)surface;
+    SessionLockSurface *self = data;
+
+    self->can_commit = true;
+
+    ext_session_lock_surface_v1_ack_configure (self->lock_surface, serial);
+
+    // trigger a commit
+
+    struct wl_array states;
+    wl_array_init(&states);
+    {
+        uint32_t *state = wl_array_add(&states, sizeof(uint32_t));
+        g_assert(state);
+        *state = XDG_TOPLEVEL_STATE_ACTIVATED;
+    }
+    {
+        uint32_t *state = wl_array_add(&states, sizeof(uint32_t));
+        g_assert(state);
+        *state = XDG_TOPLEVEL_STATE_MAXIMIZED;
+    }
+
+    LIBWAYLAND_SHIM_DISPATCH_CLIENT_EVENT(
+        xdg_toplevel_listener,
+        self->client_facing_xdg_toplevel,
+        configure,
+        self->client_facing_xdg_toplevel,
+        width, height,
+        &states);
+    wl_array_release(&states);
+
+    LIBWAYLAND_SHIM_DISPATCH_CLIENT_EVENT(
+        xdg_surface_listener,
+        self->client_facing_xdg_surface,
+        configure,
+        self->client_facing_xdg_surface,
+        serial);
+}
+
+static const struct ext_session_lock_surface_v1_listener session_lock_surface_listener = {
+    .configure = session_lock_surface_handle_configure,
+};
+
+static const struct ext_session_lock_v1_listener session_lock_listener = {
+    .locked = session_lock_handle_locked,
+    .finished = session_lock_handle_finished,
+};
+
+void
+session_lock_lock (GtkLayerShellSessionLock *self)
+{
+    GtkLayerShellSessionLockPrivate *priv = gtk_layer_session_lock_get_instance_private (self);
+    g_return_if_fail (priv);
+
+    struct ext_session_lock_manager_v1 *manager = gtk_wayland_get_session_lock_manager_global ();
+    g_return_if_fail (manager);
+
+    priv->lock = ext_session_lock_manager_v1_lock (manager);
+    ext_session_lock_v1_add_listener (priv->lock, &session_lock_listener, self);
+}
+
+void
+session_lock_destroy (GtkLayerShellSessionLock *self)
+{
+    GtkLayerShellSessionLockPrivate *priv = gtk_layer_session_lock_get_instance_private (self);
+    g_return_if_fail (priv);
+    g_return_if_fail (priv->lock);
+
+    ext_session_lock_v1_destroy (priv->lock);
+    priv->lock = NULL;
+}
+
+void
+session_lock_unlock_and_destroy (GtkLayerShellSessionLock *self)
+{
+    GtkLayerShellSessionLockPrivate *priv = gtk_layer_session_lock_get_instance_private (self);
+    g_return_if_fail (priv);
+    g_return_if_fail (priv->lock);
+
+    ext_session_lock_v1_unlock_and_destroy (priv->lock);
+    priv->lock = NULL;
+}
+
+static void
+session_lock_window_realize (GtkWindow *gtk_window, void *data)
+{
+    (void)data;
+    SessionLockSurface *surface = g_object_get_data (G_OBJECT (gtk_window), lock_surface_key);
+
+    GdkSurface *gdk_surface = gtk_native_get_surface (GTK_NATIVE (gtk_window));
+    struct wl_surface *wl_surface = gdk_wayland_surface_get_wl_surface (gdk_surface);
+    struct wl_output *wl_output = gdk_wayland_monitor_get_wl_output (surface->monitor);
+
+    surface->lock_surface = ext_session_lock_v1_get_lock_surface (surface->lock, wl_surface, wl_output);
+    g_return_if_fail (surface->lock_surface);
+
+    ext_session_lock_surface_v1_add_listener (surface->lock_surface, &session_lock_surface_listener, surface);
+}
+
+void
+session_lock_create_surface_for_window (GtkLayerShellSessionLock *self, GtkWindow *gtk_window, GdkMonitor *gdk_monitor)
+{
+    GtkLayerShellSessionLockPrivate *priv = gtk_layer_session_lock_get_instance_private (self);
+    g_return_if_fail (priv);
+    g_return_if_fail (priv->lock);
+
+    SessionLockSurface *surface = g_new0 (SessionLockSurface, 1);
+
+    surface->gtk_window = gtk_window;
+    surface->monitor = gdk_monitor;
+    surface->lock = priv->lock;
+    surface->can_commit = false;
+
+    all_lock_surfaces = g_list_append (all_lock_surfaces, surface);
+
+    g_object_set_data_full (G_OBJECT (gtk_window),
+                            lock_surface_key,
+                            surface,
+                            (GDestroyNotify) session_lock_surface_destroy);
+
+    gtk_window_set_decorated (gtk_window, FALSE);
+
+    g_signal_connect(gtk_window, "realize", G_CALLBACK (session_lock_window_realize), NULL);
+}
+
+static void
+stubbed_xdg_toplevel_handle_destroy (void* data, struct wl_proxy *proxy)
+{
+    (void)proxy;
+    SessionLockSurface *self = (SessionLockSurface *)data;
+    session_lock_surface_unmap(self);
+}
+
+static struct wl_proxy *
+stubbed_xdg_surface_handle_request (
+    void* data,
+    struct wl_proxy *proxy,
+    uint32_t opcode,
+    const struct wl_interface *interface,
+    uint32_t version,
+    uint32_t flags,
+    union wl_argument *args)
+{
+    (void)interface; (void)flags; (void)args;
+    SessionLockSurface *self = (SessionLockSurface *)data;
+
+    if (opcode == XDG_SURFACE_GET_TOPLEVEL) {
+        struct wl_proxy *toplevel = libwayland_shim_create_client_proxy (
+            proxy,
+            &xdg_toplevel_interface,
+            version,
+            NULL,
+            stubbed_xdg_toplevel_handle_destroy,
+            data);
+        self->client_facing_xdg_toplevel = (struct xdg_toplevel *)toplevel;
+        return toplevel;
+    } else {
+        return NULL;
+    }
+}
+
+static void
+stubbed_xdg_surface_handle_destroy (void* data, struct wl_proxy *proxy)
+{
+    (void)proxy;
+    SessionLockSurface *self = (SessionLockSurface *)data;
+    session_lock_surface_unmap(self);
+}
+
+gint find_lock_surface_by_id (gconstpointer lock_surface, gconstpointer needle_ptr)
+{
+    const uint32_t needle = *(uint32_t *)needle_ptr;
+    const SessionLockSurface *self = lock_surface;
+    GdkSurface *gdk_surface = gtk_native_get_surface (GTK_NATIVE (self->gtk_window));
+    if (!gdk_surface) return 1;
+
+    struct wl_surface *wl_surface = gdk_wayland_surface_get_wl_surface (gdk_surface);
+    uint32_t id = wl_proxy_get_id((struct wl_proxy *)wl_surface);
+
+    return id == needle ? 0 : 1;
+}
+
+gboolean
+session_lock_surface_handle_request (
+    struct wl_proxy *proxy,
+    uint32_t opcode,
+    const struct wl_interface *interface,
+    uint32_t version,
+    uint32_t flags,
+    union wl_argument *args,
+    struct wl_proxy **ret_proxy)
+{
+    (void)interface;
+    (void)flags;
+    const char* type = proxy->object.interface->name;
+    if (strcmp(type, xdg_wm_base_interface.name) == 0) {
+        if (opcode == XDG_WM_BASE_GET_XDG_SURFACE) {
+            struct wl_surface *wl_surface = (struct wl_surface *)args[1].o;
+            uint32_t id = wl_proxy_get_id((struct wl_proxy *)wl_surface);
+
+            GList *lock_surface_entry = g_list_find_custom (all_lock_surfaces, &id, find_lock_surface_by_id);
+            if (lock_surface_entry) {
+                SessionLockSurface *self = lock_surface_entry->data;
+                struct wl_proxy *xdg_surface = libwayland_shim_create_client_proxy (
+                    proxy,
+                    &xdg_surface_interface,
+                    version,
+                    stubbed_xdg_surface_handle_request,
+                    stubbed_xdg_surface_handle_destroy,
+                    self);
+                self->client_facing_xdg_surface = (struct xdg_surface *)xdg_surface;
+                *ret_proxy = xdg_surface;
+                return TRUE;
+            }
+        }
+    }
+
+    if (strcmp(type, wl_surface_interface.name) == 0) {
+        // We don't need to install a proxy here since we pretty much only want
+        // to prevent commits until the first configure event has been ack'ed.
+        if (opcode == WL_SURFACE_COMMIT) {
+            GList *lock_surface_entry = g_list_find_custom (all_lock_surfaces, &proxy->object.id, find_lock_surface_by_id);
+            if (lock_surface_entry) {
+                SessionLockSurface *self = lock_surface_entry->data;
+                if (!self->can_commit) {
+                    return TRUE;
+                }
+            }
+        }
+    }
+
+    return FALSE;
+}

--- a/src/session-lock.h
+++ b/src/session-lock.h
@@ -1,0 +1,42 @@
+#ifndef SESSSION_LOCK_H
+#define SESSSION_LOCK_H
+
+#include "ext-session-lock-v1-client.h"
+#include "gtk4-layer-shell.h"
+#include <gtk/gtk.h>
+
+void session_lock_lock (GtkLayerShellSessionLock *self);
+
+void session_lock_destroy (GtkLayerShellSessionLock *self);
+
+void session_lock_unlock_and_destroy (GtkLayerShellSessionLock *self);
+
+void session_lock_create_surface_for_window (GtkLayerShellSessionLock *self, GtkWindow *gtk_window, GdkMonitor *gdk_monitor);
+
+typedef struct _SessionLockSurface SessionLockSurface;
+
+struct _SessionLockSurface
+{
+    GtkWindow *gtk_window;
+    GdkMonitor *monitor;
+
+    // Not set by user requests
+    struct ext_session_lock_v1 *lock;
+    struct ext_session_lock_surface_v1 *lock_surface; // Can be null
+    struct xdg_surface *client_facing_xdg_surface;
+    struct xdg_toplevel *client_facing_xdg_toplevel;
+
+    bool can_commit;
+};
+
+// Used by libwayland wrappers
+gboolean session_lock_surface_handle_request (
+    struct wl_proxy *proxy,
+    uint32_t opcode,
+    const struct wl_interface *interface,
+    uint32_t version,
+    uint32_t flags,
+    union wl_argument *args,
+    struct wl_proxy **ret_proxy);
+
+#endif // SESSSION_LOCK_H

--- a/src/wayland-utils.c
+++ b/src/wayland-utils.c
@@ -5,6 +5,7 @@
 
 static struct wl_registry *wl_registry_global = NULL;
 static struct zwlr_layer_shell_v1 *layer_shell_global = NULL;
+static struct ext_session_lock_manager_v1 *session_lock_manager_global = NULL;
 
 static gboolean has_initialized = FALSE;
 
@@ -12,6 +13,12 @@ struct zwlr_layer_shell_v1 *
 gtk_wayland_get_layer_shell_global ()
 {
     return layer_shell_global;
+}
+
+struct ext_session_lock_manager_v1 *
+gtk_wayland_get_session_lock_manager_global ()
+{
+    return session_lock_manager_global;
 }
 
 static void
@@ -30,6 +37,14 @@ wl_registry_handle_global (void *_data,
                                                id,
                                                &zwlr_layer_shell_v1_interface,
                                                MIN((uint32_t)zwlr_layer_shell_v1_interface.version, version));
+    }
+
+    if (strcmp (interface, ext_session_lock_manager_v1_interface.name) == 0) {
+        g_warn_if_fail (ext_session_lock_manager_v1_interface.version >= 1);
+        session_lock_manager_global = wl_registry_bind (registry,
+                                                        id,
+                                                        &ext_session_lock_manager_v1_interface,
+                                                        MIN((uint32_t)ext_session_lock_manager_v1_interface.version, version));
     }
 }
 

--- a/src/wayland-utils.h
+++ b/src/wayland-utils.h
@@ -3,12 +3,14 @@
 
 #include "xdg-shell-client.h"
 #include "wlr-layer-shell-unstable-v1-client.h"
+#include "ext-session-lock-v1-client.h"
 #include "gtk4-layer-shell.h"
 #include <gdk/gdk.h>
 #include <gdk/gdk.h>
 
 void gtk_wayland_init_if_needed (void);
 struct zwlr_layer_shell_v1 *gtk_wayland_get_layer_shell_global (void);
+struct ext_session_lock_manager_v1 *gtk_wayland_get_session_lock_manager_global (void);
 
 enum zwlr_layer_shell_v1_layer gtk_layer_shell_layer_get_zwlr_layer_shell_v1_layer (GtkLayerShellLayer layer);
 uint32_t gtk_layer_shell_edge_array_get_zwlr_layer_shell_v1_anchor (gboolean edges[GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER]);


### PR DESCRIPTION
As discussed, this is completely raw and unpolished, no comments or documentation, and probably a lot of unnecessary code. The example shows exactly how to use the protocol, but make sure to run it in a nested session so you don't accidentally lock yourself out :sweat_smile:

The main differences to the layer shell protocol are:
1. We have to prevent the surface from being committed until we've ack'ed the first configure requested from the session lock protocol. No need for a proxy here, since we just need to prevent it
2. The surfaces have to be passed to the protocol on realize so that no buffer is attached yet and the surface is not yet committed
3. After the first ack, we have a size and send an XDG configure request to the client, so that the surface is committed with the correct size by gtk
4. Since we don't have the surface yet when we need to prevent the surface commit, we need to compare wayland object ids instead (couldn't figure out how to get the pointer if it's not in an argument, and `wl_surface.commit` has no args)

It's possible that there are edge cases where other requirements of the protocol are violated (I could imagine the "no role must be attached" causing problems somehow), and I'm sure it's possible to improve the code intercepting the surface commit. It's working though :smile:

I had to prefix everything with `gtk_layer` and `GtkLayerShell` for the introspection to keep working correctly, might be nicer if we can add more prefixes for that.