### PR TITLE
Control which symbols are exposed

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -22,7 +22,7 @@ executable(
     install: false)
 
 if get_option('vapi')
-    add_languages('vala')
+    add_languages('vala', native: false)
     executable(
         'simple-example-vala',
         files('simple-example.vala'),

--- a/include/gtk4-layer-shell.h
+++ b/include/gtk4-layer-shell.h
@@ -35,6 +35,8 @@
  * to keep the window the smallest it can be while still fitting its contents.
  */
 
+#define GTK4_LAYER_SHELL_EXPORT __attribute__((__visibility__("default")))
+
 G_BEGIN_DECLS
 
 /**

--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -22,6 +22,8 @@
  * [linking.md](https://github.com/wmww/gtk4-layer-shell/blob/main/linking.md) for details.
  */
 
+#define GTK4_LAYER_SHELL_EXPORT __attribute__((__visibility__("default")))
+
 G_BEGIN_DECLS
 
 /**
@@ -40,6 +42,7 @@ gboolean gtk_session_lock_is_supported();
  * An instance of the object used to control locking the screen.
  * Multiple instances can exist at once, but only one can be locked at a time.
  */
+GTK4_LAYER_SHELL_EXPORT
 G_DECLARE_FINAL_TYPE(GtkSessionLockInstance, gtk_session_lock_instance, GTK_SESSION_LOCK, INSTANCE, GObject)
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('gtk4-layer-shell',
     ['c'],
     version: '1.1.0',
     license: 'MIT',
-    meson_version: '>=0.51.0',
+    meson_version: '>=0.54.0',
     default_options: ['c_std=gnu11', 'warning_level=3'])
 
 lib_so_version = '0'

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ add_project_arguments(
         '-Wno-pedantic',
         '-Werror=implicit-function-declaration',
         '-Werror=return-type',
+        '-fvisibility=hidden',
     ],
     language: 'c')
 

--- a/src/gtk4-layer-shell.c
+++ b/src/gtk4-layer-shell.c
@@ -14,14 +14,17 @@ struct gtk_layer_surface_t {
     GdkMonitor* monitor;
 };
 
+GTK4_LAYER_SHELL_EXPORT
 guint gtk_layer_get_major_version() {
     return GTK_LAYER_SHELL_MAJOR;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 guint gtk_layer_get_minor_version() {
     return GTK_LAYER_SHELL_MINOR;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 guint gtk_layer_get_micro_version() {
     return GTK_LAYER_SHELL_MICRO;
 }
@@ -35,10 +38,12 @@ static struct zwlr_layer_shell_v1* init_and_get_layer_shell_global() {
     return get_layer_shell_global_from_display(wl_display);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_layer_is_supported() {
     return init_and_get_layer_shell_global() != NULL && libwayland_shim_has_initialized();
 }
 
+GTK4_LAYER_SHELL_EXPORT
 guint gtk_layer_get_protocol_version() {
     struct zwlr_layer_shell_v1* layer_shell_global = init_and_get_layer_shell_global();
     if (!layer_shell_global) {
@@ -115,6 +120,7 @@ static void gtk_layer_surface_remap(struct layer_surface_t* super) {
     gtk_widget_map(GTK_WIDGET(self->gtk_window));
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_init_for_window(GtkWindow* window) {
     if (!GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default())) {
         g_warning("Failed to initialize layer surface, not on Wayland");
@@ -163,27 +169,32 @@ void gtk_layer_init_for_window(GtkWindow* window) {
     }
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_layer_is_layer_window(GtkWindow* window) {
     return gtk_window_get_layer_surface(window) != NULL;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 struct zwlr_layer_surface_v1* gtk_layer_get_zwlr_layer_surface_v1(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return NULL;
     return layer_surface->super.layer_surface;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_namespace(GtkWindow* window, char const* name_space) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
     layer_surface_set_name_space(&layer_surface->super, name_space);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 const char* gtk_layer_get_namespace(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     return layer_surface_get_namespace(&layer_surface->super); // NULL-safe
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_layer(GtkWindow* window, GtkLayerShellLayer layer) {
     g_return_if_fail(layer >= 0 && layer < GTK_LAYER_SHELL_LAYER_ENTRY_NUMBER);
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
@@ -192,6 +203,7 @@ void gtk_layer_set_layer(GtkWindow* window, GtkLayerShellLayer layer) {
     layer_surface_set_layer(&layer_surface->super, (enum zwlr_layer_shell_v1_layer)layer);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 GtkLayerShellLayer gtk_layer_get_layer(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return GTK_LAYER_SHELL_LAYER_TOP;
@@ -199,6 +211,7 @@ GtkLayerShellLayer gtk_layer_get_layer(GtkWindow* window) {
     return (GtkLayerShellLayer)layer_surface->super.layer;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_monitor(GtkWindow* window, GdkMonitor* monitor) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
@@ -212,12 +225,14 @@ void gtk_layer_set_monitor(GtkWindow* window, GdkMonitor* monitor) {
     layer_surface->monitor = monitor;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 GdkMonitor* gtk_layer_get_monitor(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return NULL;
     return layer_surface->monitor;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_anchor(GtkWindow* window, GtkLayerShellEdge edge, gboolean anchor_to_edge) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
@@ -232,6 +247,7 @@ void gtk_layer_set_anchor(GtkWindow* window, GtkLayerShellEdge edge, gboolean an
     layer_surface_set_anchor(&layer_surface->super, anchored);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_layer_get_anchor(GtkWindow* window, GtkLayerShellEdge edge) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return FALSE;
@@ -244,6 +260,7 @@ gboolean gtk_layer_get_anchor(GtkWindow* window, GtkLayerShellEdge edge) {
     }
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_margin(GtkWindow* window, GtkLayerShellEdge edge, int margin_size) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
@@ -258,6 +275,7 @@ void gtk_layer_set_margin(GtkWindow* window, GtkLayerShellEdge edge, int margin_
     layer_surface_set_margin(&layer_surface->super, margins);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 int gtk_layer_get_margin(GtkWindow* window, GtkLayerShellEdge edge) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return 0;
@@ -270,30 +288,35 @@ int gtk_layer_get_margin(GtkWindow* window, GtkLayerShellEdge edge) {
     }
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_exclusive_zone(GtkWindow* window, int exclusive_zone) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
     layer_surface_set_exclusive_zone(&layer_surface->super, exclusive_zone);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 int gtk_layer_get_exclusive_zone(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return 0;
     return layer_surface->super.exclusive_zone;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_auto_exclusive_zone_enable(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return;
     layer_surface_auto_exclusive_zone_enable(&layer_surface->super);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_layer_auto_exclusive_zone_is_enabled(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return FALSE;
     return layer_surface->super.auto_exclusive_zone;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_layer_set_keyboard_mode(GtkWindow* window, GtkLayerShellKeyboardMode mode) {
     g_return_if_fail(mode >= 0 && mode < GTK_LAYER_SHELL_KEYBOARD_MODE_ENTRY_NUMBER);
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
@@ -302,6 +325,7 @@ void gtk_layer_set_keyboard_mode(GtkWindow* window, GtkLayerShellKeyboardMode mo
     layer_surface_set_keyboard_mode(&layer_surface->super, (enum zwlr_layer_surface_v1_keyboard_interactivity)mode);
 }
 
+GTK4_LAYER_SHELL_EXPORT
 GtkLayerShellKeyboardMode gtk_layer_get_keyboard_mode(GtkWindow* window) {
     struct gtk_layer_surface_t* layer_surface = gtk_window_get_layer_surface_or_warn(window);
     if (!layer_surface) return GTK_LAYER_SHELL_KEYBOARD_MODE_NONE;

--- a/src/gtk4-session-lock.c
+++ b/src/gtk4-session-lock.c
@@ -9,6 +9,7 @@
 static const char* lock_surface_key = "wayland_layer_surface";
 static GList* all_lock_surfaces = NULL;
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_session_lock_is_supported() {
     gtk_init();
     GdkDisplay* gdk_display = gdk_display_get_default();
@@ -55,6 +56,7 @@ static void gtk_session_lock_instance_init(GtkSessionLockInstance *self) {
     self->failed = FALSE;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 GtkSessionLockInstance* gtk_session_lock_instance_new() {
     return g_object_new(gtk_session_lock_instance_get_type(), NULL);
 }
@@ -79,6 +81,7 @@ static void session_lock_locked_callback_impl(bool locked, void* data) {
     );
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_session_lock_instance_lock(GtkSessionLockInstance* self) {
     if (self->has_requested_lock) {
         g_warning("Tried to lock multiple times without unlocking");
@@ -117,6 +120,7 @@ gboolean gtk_session_lock_instance_lock(GtkSessionLockInstance* self) {
     return !self->failed;
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_session_lock_instance_unlock(GtkSessionLockInstance* self) {
     if (self->is_locked) {
         self->is_locked = FALSE;
@@ -126,6 +130,7 @@ void gtk_session_lock_instance_unlock(GtkSessionLockInstance* self) {
     }
 }
 
+GTK4_LAYER_SHELL_EXPORT
 gboolean gtk_session_lock_instance_is_locked(GtkSessionLockInstance* self) {
     return self->is_locked;
 }
@@ -170,6 +175,7 @@ static void on_window_mapped(GtkWindow *window, gpointer data) {
     }
 }
 
+GTK4_LAYER_SHELL_EXPORT
 void gtk_session_lock_instance_assign_window_to_monitor(
     GtkSessionLockInstance* self,
     GtkWindow *window,

--- a/src/libwayland-shim.c
+++ b/src/libwayland-shim.c
@@ -169,6 +169,7 @@ static void client_proxy_destroy(struct wl_proxy* proxy) {
 }
 
 // Overrides the function in wayland-client.c in libwayland
+__attribute__((__visibility__("default")))
 void wl_proxy_destroy(struct wl_proxy* proxy) {
     libwayland_shim_init();
     if (proxy->object.id == client_facing_proxy_id) {
@@ -241,6 +242,7 @@ static struct wl_proxy* validate_request_result(
 
 // Overrides the function in wayland-client.c in libwayland, handles requests made by the client program and optionally
 // forwards them to libwayland/the compositor
+__attribute__((__visibility__("default")))
 struct wl_proxy* wl_proxy_marshal_array_flags(
     struct wl_proxy* proxy,
     uint32_t opcode,

--- a/src/stolen-from-libwayland.c
+++ b/src/stolen-from-libwayland.c
@@ -52,6 +52,7 @@ wl_argument_from_va_list(const char *signature, union wl_argument *args,
 // override all functions that call it.
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 struct wl_proxy *
 wl_proxy_marshal_flags(struct wl_proxy *proxy, uint32_t opcode,
 		       const struct wl_interface *interface,
@@ -70,6 +71,7 @@ wl_proxy_marshal_flags(struct wl_proxy *proxy, uint32_t opcode,
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 void
 wl_proxy_marshal(struct wl_proxy *proxy, uint32_t opcode, ...)
 {
@@ -85,6 +87,7 @@ wl_proxy_marshal(struct wl_proxy *proxy, uint32_t opcode, ...)
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 void
 wl_proxy_marshal_array(struct wl_proxy *proxy, uint32_t opcode,
 		       union wl_argument *args)
@@ -93,6 +96,7 @@ wl_proxy_marshal_array(struct wl_proxy *proxy, uint32_t opcode,
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 struct wl_proxy *
 wl_proxy_marshal_constructor(struct wl_proxy *proxy,
 			     uint32_t opcode,
@@ -112,6 +116,7 @@ wl_proxy_marshal_constructor(struct wl_proxy *proxy,
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 struct wl_proxy *
 wl_proxy_marshal_constructor_versioned(struct wl_proxy *proxy,
 				       uint32_t opcode,
@@ -133,6 +138,7 @@ wl_proxy_marshal_constructor_versioned(struct wl_proxy *proxy,
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 struct wl_proxy *
 wl_proxy_marshal_array_constructor(struct wl_proxy *proxy,
 				   uint32_t opcode, union wl_argument *args,
@@ -144,6 +150,7 @@ wl_proxy_marshal_array_constructor(struct wl_proxy *proxy,
 }
 
 // wayland-client.c
+__attribute__((__visibility__("default")))
 struct wl_proxy *
 wl_proxy_marshal_array_constructor_versioned(struct wl_proxy *proxy,
 					     uint32_t opcode,

--- a/test/lock-tests/test-async-failure.c
+++ b/test/lock-tests/test-async-failure.c
@@ -1,17 +1,48 @@
 #include "integration-test-common.h"
 
-// Not part of the public API but we're the tests, we can do what we like
-#include "../../src/registry.h"
 #include "ext-session-lock-v1-client.h"
+#include "dlfcn.h"
 
 enum lock_state_t state = 0;
+struct ext_session_lock_manager_v1* global;
 GtkSessionLockInstance* lock;
+
+static void wl_registry_handle_global(
+    void* _data,
+    struct wl_registry* registry,
+    uint32_t id,
+    const char* interface,
+    uint32_t version
+) {
+    (void)_data;
+
+    if (strcmp(interface, ext_session_lock_manager_v1_interface.name) == 0) {
+        global = wl_registry_bind(registry, id, &ext_session_lock_manager_v1_interface, version);
+    }
+}
+
+static void wl_registry_handle_global_remove(void* _data, struct wl_registry* _registry, uint32_t _id) {
+    (void)_data;
+    (void)_registry;
+    (void)_id;
+}
+
+static const struct wl_registry_listener wl_registry_listener = {
+    .global = wl_registry_handle_global,
+    .global_remove = wl_registry_handle_global_remove,
+};
+
+static void bind_global(struct wl_display* display) {
+    struct wl_registry* registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &wl_registry_listener, NULL);
+    wl_display_roundtrip(display);
+    wl_registry_destroy(registry);
+}
 
 static void callback_0() {
     // We lock the display without going through the library in order to simulate a lock being held by another process
-    GdkDisplay* gdk_display = gdk_display_get_default();
-    struct wl_display* wl_display = gdk_wayland_display_get_wl_display(gdk_display);
-    struct ext_session_lock_manager_v1* global = get_session_lock_global_from_display(wl_display);
+    bind_global(gdk_wayland_display_get_wl_display(gdk_display_get_default()));
+    ASSERT(global);
     struct ext_session_lock_v1* session_lock = ext_session_lock_manager_v1_lock(global);
     (void)session_lock;
 }


### PR DESCRIPTION
Prevents future issues like #72, results in many symbols going away but none of them should be in use, since they were never exposed by any public headers.