### PR TITLE
docs: `gdk_display_get_monitor_at_{window -> surface}`

### DIFF
--- a/include/gtk4-layer-shell.h
+++ b/include/gtk4-layer-shell.h
@@ -221,7 +221,7 @@ void gtk_layer_set_monitor(GtkWindow* window, GdkMonitor* monitor);
  * @window: A layer surface.
  *
  * NOTE: To get which monitor the surface is actually on, use
- * gdk_display_get_monitor_at_window().
+ * gdk_display_get_monitor_at_surface().
  *
  * Returns: (transfer none) (nullable): the monitor this surface will/has requested to be on.
  */


### PR DESCRIPTION
[`gdk_display_get_monitor_at_window`](https://docs.gtk.org/gdk3/method.Display.get_monitor_at_window.html) is a GTK 3-only API that was replaced by [`gdk_display_get_monitor_at_surface`](https://docs.gtk.org/gdk4/method.Display.get_monitor_at_surface.html) in GTK 4.

In reality this is a very inconsequential change since one can just get the GdkSurface via GtkWindow's GtkNative implementation, but still.