### PR TITLE
Run tests on Sway

### DIFF
--- a/test/layer-tests/test-adapts-to-screen-size.c
+++ b/test/layer-tests/test-adapts-to-screen-size.c
@@ -4,7 +4,7 @@ static GtkWindow* window;
 
 static void callback_0() {
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 0);
-    EXPECT_MESSAGE(.create_buffer 1920 1080); // size must match DEFAULT_OUTPUT_WIDTH/DEFAULT_OUTPUT_HEIGHT in common.h
+    EXPECT_MESSAGE(new id wl_buffer 1920 1080); // size must match DEFAULT_OUTPUT_WIDTH/DEFAULT_OUTPUT_HEIGHT in common.h
 
     window = create_default_window();
 
@@ -21,14 +21,14 @@ static void callback_0() {
 }
 
 static void callback_1() {
-    EXPECT_MESSAGE(.create_buffer 600 1080); // size must match DEFAULT_OUTPUT_HEIGHT in common.h
+    EXPECT_MESSAGE(new id wl_buffer 600 1080); // size must match DEFAULT_OUTPUT_HEIGHT in common.h
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 600 0);
 
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
 }
 
 static void callback_2() {
-    EXPECT_MESSAGE(.create_buffer 600 700);
+    EXPECT_MESSAGE(new id wl_buffer 600 700);
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 600 700);
 
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
@@ -36,13 +36,13 @@ static void callback_2() {
 
 static void callback_3() {
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 700);
-    EXPECT_MESSAGE(.create_buffer 1920 700);
+    EXPECT_MESSAGE(new id wl_buffer 1920 700);
 
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
 }
 
 static void callback_4() {
-    EXPECT_MESSAGE(.create_buffer 1920 300);
+    EXPECT_MESSAGE(new id wl_buffer 1920 300);
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 300);
 
     gtk_window_set_default_size(window, 200, 300);

--- a/test/layer-tests/test-uses-widget-size.c
+++ b/test/layer-tests/test-uses-widget-size.c
@@ -4,7 +4,7 @@ static GtkWindow* window;
 static GtkWidget* child;
 
 static void callback_0() {
-    EXPECT_MESSAGE(.create_buffer 850 940);
+    EXPECT_MESSAGE(new id wl_buffer 850 940);
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 850 940);
 
     window = create_default_window();
@@ -16,7 +16,7 @@ static void callback_0() {
 }
 
 static void callback_1() {
-    EXPECT_MESSAGE(.create_buffer 1001 610);
+    EXPECT_MESSAGE(new id wl_buffer 1001 610);
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 1001 610);
 
     gtk_widget_set_size_request(child, 1001, 610);
@@ -24,7 +24,7 @@ static void callback_1() {
 
 static void callback_2() {
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 1001 0);
-    EXPECT_MESSAGE(.create_buffer 1001 1080); // size must match DEFAULT_OUTPUT_HEIGHT in common.h
+    EXPECT_MESSAGE(new id wl_buffer 1001 1080); // size must match DEFAULT_OUTPUT_HEIGHT in common.h
 
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_TOP, TRUE);
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
@@ -32,14 +32,14 @@ static void callback_2() {
 
 static void callback_3() {
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 0 0);
-    EXPECT_MESSAGE(.create_buffer 1920 1080);
+    EXPECT_MESSAGE(new id wl_buffer 1920 1080);
 
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
     gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
 }
 
 static void callback_4() {
-    EXPECT_MESSAGE(.create_buffer 555 777);
+    EXPECT_MESSAGE(new id wl_buffer 555 777);
     EXPECT_MESSAGE(zwlr_layer_surface_v1 .set_size 555 777);
 
     gtk_widget_set_size_request(child, 555, 777);

--- a/test/mock-server/mock-server.c
+++ b/test/mock-server/mock-server.c
@@ -3,9 +3,9 @@
 struct wl_display* display = NULL;
 
 static const char* get_display_name() {
-    const char* result = getenv("WAYLAND_DISPLAY");
+    const char* result = getenv("CREATE_DISPLAY");
     if (!result) {
-        FATAL("WAYLAND_DISPLAY not set");
+        FATAL("CREATE_DISPLAY not set");
     }
     return result;
 }


### PR DESCRIPTION
Run the test suite on Sway. Currently this works, but is quite hacky and breaks the normal way of running tests on the mock server. Would need to support both ways of running tests before merging.