### PR TITLE
Tests: refactor how env vars are handled

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,20 @@ This directory is home to the gtk4-layer-shell test suite.
 ## To run tests
 `ninja -C build test` (where `build` is the path to your build directory).
 
-### To add a new integration test
+### To run a single test
+```
+meson test -C build --verbose [testname]
+```
+
+If you want to run the test client and server separately (for example, to run either in `wayland-debug`):
+```bash
+# server:
+ninja -C build && GTKLS_TEST_DIR=/tmp ./build/test/mock-server/mock-server
+# client:
+ninja -C build && GTKLS_TEST_DIR=/tmp ./build/test/[testname] --auto
+```
+
+## To add a new integration test
 1. Copy an existing integration test file
 2. Implement your test as a series of one or more callbacks
 3. Add its name to the list in `test/integration-tests/meson.build`

--- a/test/mock-server/mock-server.c
+++ b/test/mock-server/mock-server.c
@@ -2,18 +2,11 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 
 struct wl_display* display = NULL;
 
 static void open_command_stream();
-
-static const char* get_display_name() {
-    const char* result = getenv("WAYLAND_DISPLAY");
-    if (!result) {
-        FATAL("WAYLAND_DISPLAY not set");
-    }
-    return result;
-}
 
 struct request_override_t {
     const struct wl_message* message;
@@ -22,6 +15,23 @@ struct request_override_t {
 };
 
 struct wl_list request_overrides;
+
+char wayland_display[255] = {0};
+char command_fifo_path[255] = {0};
+char response_fifo_path[255] = {0};
+static void init_paths() {
+    const char* test_dir = getenv("GTKLS_TEST_DIR");
+    if (!test_dir) {
+        test_dir = getenv("XDG_RUNTIME_DIR");
+    }
+    if (!test_dir || strlen(test_dir) == 0) {
+        FATAL_FMT("GTKLS_TEST_DIR or XDG_RUNTIME_DIR must be set");
+    }
+    ASSERT(strlen(test_dir) < 200);
+    sprintf(wayland_display, "%s/gtkls-test-display", test_dir);
+    sprintf(command_fifo_path, "%s/gtkls-test-command", test_dir);
+    sprintf(response_fifo_path, "%s/gtkls-test-response", test_dir);
+}
 
 void install_request_override(
     const struct wl_interface* interface,
@@ -108,6 +118,7 @@ char type_code_at_index(const struct wl_message* message, int index) {
 }
 
 static void client_disconnect(struct wl_listener *listener, void *data) {
+    printf("Client disconnected\n");
     wl_display_terminate(display);
 }
 
@@ -124,12 +135,9 @@ static struct wl_listener client_connect_listener = {
     .notify = client_connect,
 };
 
-
 static void send_command_response(char* command) {
-    const char* fifo_path = getenv("SERVER_TO_CLIENT_FIFO");
-    ASSERT(fifo_path);
     int fd;
-    ASSERT((fd = open(fifo_path, O_WRONLY)) >= 0);
+    ASSERT((fd = open(response_fifo_path, O_WRONLY)) >= 0);
     const char* argv[20] = {command};
     int argc = 1;
     while (*command) {
@@ -178,11 +186,9 @@ static void open_command_stream() {
     if (event_source) {
         wl_event_source_remove(event_source);
     }
-    const char* fifo_path = getenv("CLIENT_TO_SERVER_FIFO");
-    ASSERT(fifo_path);
     int fd;
-    mkfifo(fifo_path, 0666);
-    ASSERT((fd = open(fifo_path, O_RDONLY | O_NONBLOCK)) >= 0);
+    mkfifo(command_fifo_path, 0666);
+    ASSERT((fd = open(command_fifo_path, O_RDONLY | O_NONBLOCK)) >= 0);
     event_source = wl_event_loop_add_fd(
         wl_display_get_event_loop(display),
         fd,
@@ -195,9 +201,11 @@ static void open_command_stream() {
 int main(int argc, const char** argv) {
     wl_list_init(&request_overrides);
 
+    init_paths();
+
     display = wl_display_create();
-    if (wl_display_add_socket(display, get_display_name()) != 0) {
-        FATAL_FMT("server failed to connect to Wayland display %s", get_display_name());
+    if (wl_display_add_socket(display, wayland_display) != 0) {
+        FATAL_FMT("server failed to connect to Wayland display %s", wayland_display);
     }
 
     open_command_stream();

--- a/test/run-integration-test.py
+++ b/test/run-integration-test.py
@@ -17,22 +17,22 @@ cleanup_funcs = []
 class TestError(RuntimeError):
     pass
 
-def get_xdg_runtime_dir() -> str:
+def get_test_dir() -> str:
     '''
-    Creates a directory to use as the XDG_RUNTIME_DIR.
+    Creates a directory to use as the test directory.
     It bases the result on the current PID because each test running in parallel needs a unique directory.
     '''
-    tmp_runtime_dir = '/tmp/layer-shell-test-runtime-dir-' + str(os.getpid())
-    if (path.exists(tmp_runtime_dir)):
+    tmp_test_dir = '/tmp/gtkls-test-' + str(os.getpid())
+    if (path.exists(tmp_test_dir)):
         # We should wipe the dir on cleanup, but things can go wrong
-        wipe_xdg_runtime_dir(tmp_runtime_dir)
-    os.mkdir(tmp_runtime_dir)
-    cleanup_funcs.append(lambda: wipe_xdg_runtime_dir(tmp_runtime_dir))
-    return tmp_runtime_dir
+        wipe_test_dir(tmp_test_dir)
+    os.mkdir(tmp_test_dir)
+    cleanup_funcs.append(lambda: wipe_test_dir(tmp_test_dir))
+    return tmp_test_dir
 
-def wipe_xdg_runtime_dir(p: str):
+def wipe_test_dir(p: str):
     assert p.startswith('/tmp'), 'Sanity check'
-    assert 'layer-shell-test-runtime-dir' in p, 'Sanity check'
+    assert 'gtkls-test-' in p, 'Sanity check'
     shutil.rmtree(p)
 
 def wait_until_appears(p: str):
@@ -157,22 +157,22 @@ class Program:
     def collect_output(self):
         return self.stdout.collect_str(), self.stderr.collect_str()
 
-def run_test(name: str, server_args: List[str], client_args: List[str], xdg_runtime: str, wayland_display: str) -> str:
+def run_test(name: str, server_args: List[str], client_args: List[str], test_dir: str) -> str:
     '''
     Runs two processes: a mock server and the test client
     Does *not* check that client's message assertions pass, this must be done later using the returned output
     '''
+    wayland_display = path.join(test_dir, 'gtkls-test-display')
     env = os.environ.copy()
-    env['XDG_RUNTIME_DIR'] = xdg_runtime
+    env['GTKLS_TEST_DIR'] = test_dir
+    env['XDG_RUNTIME_DIR'] = test_dir
     env['WAYLAND_DISPLAY'] = wayland_display
-    env['CLIENT_TO_SERVER_FIFO'] = xdg_runtime + '/' + wayland_display + '-c2s'
-    env['SERVER_TO_CLIENT_FIFO'] = xdg_runtime + '/' + wayland_display + '-s2c'
     env['WAYLAND_DEBUG'] = '1'
 
     server = Program('server', server_args, env)
 
     try:
-        wait_until_appears(path.join(xdg_runtime, wayland_display))
+        wait_until_appears(wayland_display)
     except TestError as e:
         server.kill()
         raise TestError(server.format_output() + '\n\n' + str(e))
@@ -264,10 +264,9 @@ def main():
     assert os.access(client_bin, os.X_OK), client_bin + ' is not executable'
     assert path.exists(server_bin), 'Could not find server at ' + server_bin
     assert os.access(server_bin, os.X_OK), server_bin + ' is not executable'
-    wayland_display = 'wayland-test'
-    xdg_runtime = get_xdg_runtime_dir()
+    test_dir = get_test_dir()
 
-    client_stderr = run_test(name, [server_bin], [client_bin, '--auto'], xdg_runtime, wayland_display)
+    client_stderr = run_test(name, [server_bin], [client_bin, '--auto'], test_dir)
     client_lines = [line.strip() for line in client_stderr.strip().splitlines()]
 
     try:


### PR DESCRIPTION
Makes it a bit simpler to run a test in wayland-debug without the python script