### PR TITLE
Block null buffers committed to session lock surfaces

### DIFF
--- a/test/integration-test-common/integration-test-common.c
+++ b/test/integration-test-common/integration-test-common.c
@@ -182,5 +182,7 @@ int main(int argc, char** argv) {
     while (g_list_model_get_n_items(gtk_window_get_toplevels()) > 0)
         g_main_context_iteration(NULL, TRUE);
 
+    wl_display_roundtrip(gdk_wayland_display_get_wl_display(gdk_display_get_default()));
+
     return return_code;
 }

--- a/test/mock-server/overrides.c
+++ b/test/mock-server/overrides.c
@@ -426,6 +426,11 @@ REQUEST_OVERRIDE_IMPL(ext_session_lock_surface_v1, ack_configure) {
     }
 }
 
+REQUEST_OVERRIDE_IMPL(ext_session_lock_surface_v1, destroy) {
+    struct surface_data_t* data = wl_resource_get_user_data(ext_session_lock_surface_v1);
+    data->lock_surface = NULL;
+}
+
 void init() {
     OVERRIDE_REQUEST(wl_surface, commit);
     OVERRIDE_REQUEST(wl_surface, frame);
@@ -453,6 +458,7 @@ void init() {
     OVERRIDE_REQUEST(ext_session_lock_v1, unlock_and_destroy);
     OVERRIDE_REQUEST(ext_session_lock_v1, get_lock_surface);
     OVERRIDE_REQUEST(ext_session_lock_surface_v1, ack_configure);
+    OVERRIDE_REQUEST(ext_session_lock_surface_v1, destroy);
 
     wl_global_create(display, &wl_seat_interface, 6, NULL, wl_seat_bind);
     wl_global_create(display, &wl_output_interface, 2, NULL, wl_output_bind);


### PR DESCRIPTION
GTK commits null buffers when hiding surfaces, which it does before destroying them. This seems to be allowed by Sway as long as the lock surface object is destroyed first, but a strict reading of the protocol indicates it's technically forbidden (and it's forbidden by the test server). This wasn't an obvious problem before because Sway is forgiving, and also two unrelated bugs
1. The tests weren't roundtripping at the end, so the mock server wasn't seeing the null buffer attach before shutting down (fixed by this PR)
2. We leak surfaces (not fixed yet)