### PR TITLE
Session lock: dont leak windows

### DIFF
--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -106,9 +106,10 @@ gboolean gtk_session_lock_instance_is_locked(GtkSessionLockInstance* self);
  * @window: The GTK Window to use as a lock surface
  * @monitor: (not nullable): The monitor to show it on
  *
- * This must be called with a different window once for each monitor, immediately after calling
- * gtk_session_lock_lock(). Hiding a window that is active on a monitor or not letting a window be resized by the
- * library is not allowed (may result in a Wayland protocol error).
+ * This must be called with a different window once for each monitor immediately after calling gtk_session_lock_lock().
+ * Hiding a window that is active on a monitor or not letting a window be resized by the library is not allowed (may
+ * result in a Wayland protocol error). The window will be unmapped and gtk_window_destroy() called on it when the
+ * current lock ends, but you can continue to use it if you hold a strong reference.
  */
 void gtk_session_lock_instance_assign_window_to_monitor(
     GtkSessionLockInstance* self,

--- a/src/gtk4-session-lock.c
+++ b/src/gtk4-session-lock.c
@@ -72,6 +72,7 @@ GtkSessionLockInstance* gtk_session_lock_instance_new() {
 static void clear_lock_surfaces(GtkSessionLockInstance* self) {
     for (GList* item = self->lock_surfaces; item; item = item->next) {
         struct gtk_lock_surface_t* surface = item->data;
+        gtk_widget_unrealize(GTK_WIDGET(surface->gtk_window));
         // This destroys GTK's internal reference to the window, the program could still be holding a reference to the
         // window if it wants to keep it alive and use it again.
         gtk_window_destroy(surface->gtk_window);

--- a/test/integration-test-common/integration-test-common.c
+++ b/test/integration-test-common/integration-test-common.c
@@ -7,6 +7,7 @@ int step_time = 300;
 static int return_code = 0;
 static int callback_index = 0;
 static gboolean auto_continue = FALSE;
+static gboolean complete = FALSE;
 
 char command_fifo_path[255] = {0};
 char response_fifo_path[255] = {0};
@@ -76,6 +77,7 @@ static gboolean next_step(gpointer _data) {
     } else {
         while (g_list_model_get_n_items(gtk_window_get_toplevels()) > 0)
             gtk_window_destroy(g_list_model_get_item(gtk_window_get_toplevels(), 0));
+        complete = TRUE;
     }
     return FALSE;
 }
@@ -178,10 +180,7 @@ int main(int argc, char** argv) {
     }
 
     next_step(NULL);
-
-    while (g_list_model_get_n_items(gtk_window_get_toplevels()) > 0)
-        g_main_context_iteration(NULL, TRUE);
-
+    while (!complete) g_main_context_iteration(NULL, TRUE);
     wl_display_roundtrip(gdk_wayland_display_get_wl_display(gdk_display_get_default()));
 
     return return_code;

--- a/test/lock-tests/meson.build
+++ b/test/lock-tests/meson.build
@@ -2,6 +2,7 @@ lock_tests = [
     'test-lock-can-be-created-without-locking',
     'test-can-lock-display',
     'test-can-relock-display',
+    'test-can-reuse-lock-window',
     'test-immediate-failure',
     'test-async-failure',
     'test-popup-on-lock-screen',

--- a/test/lock-tests/test-async-failure.c
+++ b/test/lock-tests/test-async-failure.c
@@ -1,7 +1,6 @@
 #include "integration-test-common.h"
 
 #include "ext-session-lock-v1-client.h"
-#include "dlfcn.h"
 
 enum lock_state_t state = 0;
 struct ext_session_lock_manager_v1* global;

--- a/test/lock-tests/test-can-relock-display.c
+++ b/test/lock-tests/test-can-relock-display.c
@@ -24,6 +24,8 @@ static void callback_1() {
     ASSERT_EQ(state_a, LOCK_STATE_LOCKED, "%d");
 
     EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
 
     gtk_session_lock_instance_unlock(lock_a);
     ASSERT(!gtk_session_lock_instance_is_locked(lock_a));
@@ -43,6 +45,8 @@ static void callback_2() {
     ASSERT_EQ(state_a, LOCK_STATE_LOCKED, "%d");
 
     EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
 
     gtk_session_lock_instance_unlock(lock_a);
     ASSERT(!gtk_session_lock_instance_is_locked(lock_a));

--- a/test/lock-tests/test-can-reuse-lock-window.c
+++ b/test/lock-tests/test-can-reuse-lock-window.c
@@ -1,0 +1,66 @@
+#include "integration-test-common.h"
+
+enum lock_state_t state = 0;
+GtkSessionLockInstance* lock = NULL;
+GtkWindow* lock_window = NULL;
+
+static GtkWindow* get_lock_window() {
+    return lock_window;
+}
+
+static void callback_0() {
+    EXPECT_MESSAGE(ext_session_lock_manager_v1 .lock);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_v1 .locked);
+
+    lock_window = g_object_ref(create_default_window());
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals(lock, &state);
+    ASSERT(!gtk_session_lock_instance_is_locked(lock));
+
+    ASSERT(gtk_session_lock_instance_lock(lock));
+    create_lock_windows(lock, get_lock_window);
+}
+
+static void callback_1() {
+    ASSERT(gtk_session_lock_instance_is_locked(lock));
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+
+    EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    gtk_session_lock_instance_unlock(lock);
+    ASSERT(!gtk_session_lock_instance_is_locked(lock));
+    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
+}
+
+static void callback_2() {
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_v1 .locked);
+    ASSERT(gtk_session_lock_instance_lock(lock));
+    fprintf(stderr, "\nlock window: %p\n\n", lock_window);
+    create_lock_windows(lock, get_lock_window);
+    fprintf(stderr, "\nlock windows created\n\n");
+}
+
+static void callback_3() {
+    ASSERT(gtk_session_lock_instance_is_locked(lock));
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+
+    EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    gtk_session_lock_instance_unlock(lock);
+    ASSERT(!gtk_session_lock_instance_is_locked(lock));
+    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+    callback_3,
+)


### PR DESCRIPTION
Stop leaking GTK windows on repeated lock/unlocks and fix protocol errors that revealed