### PR TITLE
Add ::monitor signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,9 @@ pacman -S --needed meson ninja gtk4 wayland wayland-protocols gobject-introspect
 * `-Dvapi` (default: `true`): If to build VAPI data and Vala example. The VAPI file allows this library to be used in Vala. Requires `-Dintrospection=true`
 
 ### Running the Tests
-* `ninja -C build test`
-* Or, to run a specific test and print the complete output `meson test -C build --verbose <testname>`
-* To watch a specific test run against the currently active Wayland compositor `ninja -C build && ./build/test/<testname> --auto`
-* To run the test in interactive mode it's same as above, but without the `--auto` flag
-* If you have [wayland-debug](https://github.com/wmww/wayland-debug), `wayland-debug -f 'zwlr_*, xdg_*' -r ./build/test/<testname> --auto` can be helpful for debugging
+* To run all tests its `ninja -C build test`
+* To run a specific test and print the complete output `ninja -C build && meson test -C build --verbose <testname>`
+* See [test/README.md](test/README.md) for more info and tips
 
 ## Licensing
 100% MIT (unlike the GTK3 version of this library which contained GPL code copied from GTK)

--- a/examples/session-lock.c
+++ b/examples/session-lock.c
@@ -50,7 +50,6 @@ static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor *monitor, void* 
     gtk_widget_set_tooltip_text(button, "Foo Bar Baz");
 
     gtk_window_set_child(GTK_WINDOW(gtk_window), box);
-    gtk_window_present(gtk_window);
 }
 
 static void lock_display(GtkSessionLockInstance* lock) {

--- a/examples/session-lock.c
+++ b/examples/session-lock.c
@@ -3,32 +3,34 @@
 
 static GtkApplication* app = NULL;
 
-static void unlock(GtkButton *button, void *data) {
+static void on_unlock_button_clicked(GtkButton *button, void *data) {
     (void)button;
     GtkSessionLockInstance* lock = data;
     gtk_session_lock_instance_unlock(lock);
 }
 
-static void locked(GtkSessionLockInstance *lock, void *data) {
+static void on_locked(GtkSessionLockInstance *lock, void *data) {
     (void)lock;
     (void)data;
     g_message("Session locked successfully");
 }
 
-static void failed(GtkSessionLockInstance *lock, void *data) {
+static void on_failed(GtkSessionLockInstance *lock, void *data) {
     (void)lock;
     (void)data;
     g_critical("The session could not be locked");
     g_application_quit(G_APPLICATION(app));
 }
 
-static void unlocked(GtkSessionLockInstance *lock, void *data) {
+static void on_unlocked(GtkSessionLockInstance *lock, void *data) {
     (void)lock;
     (void)data;
     g_message("Session unlocked");
 }
 
-static void create_lock_surface(GtkSessionLockInstance* lock, GdkMonitor *monitor) {
+static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor *monitor, void* data) {
+    (void)data;
+
     GtkWindow *gtk_window = GTK_WINDOW(gtk_application_window_new(app));
     gtk_session_lock_instance_assign_window_to_monitor(lock, gtk_window, monitor);
 
@@ -41,7 +43,7 @@ static void create_lock_surface(GtkSessionLockInstance* lock, GdkMonitor *monito
     gtk_box_append(GTK_BOX(box), label);
 
     GtkWidget *button = gtk_button_new_with_label("Unlock");
-    g_signal_connect(button, "clicked", G_CALLBACK(unlock), lock);
+    g_signal_connect(button, "clicked", G_CALLBACK(on_unlock_button_clicked), lock);
     gtk_box_append(GTK_BOX(box), button);
 
     // Not displayed, but allows testing that creating popups doesn't crash GTK
@@ -51,31 +53,16 @@ static void create_lock_surface(GtkSessionLockInstance* lock, GdkMonitor *monito
     gtk_window_present(gtk_window);
 }
 
-static void create_lock_surface_for_all_monitors(GtkSessionLockInstance* lock) {
-    GdkDisplay *display = gdk_display_get_default();
-    GListModel *monitors = gdk_display_get_monitors(display);
-    guint n_monitors = g_list_model_get_n_items(monitors);
-
-    for (guint i = 0; i < n_monitors; ++i) {
-        GdkMonitor *monitor = g_list_model_get_item(monitors, i);
-        create_lock_surface(lock, monitor);
-    }
-}
-
 static void lock_display(GtkSessionLockInstance* lock) {
-    if (gtk_session_lock_instance_lock(lock)) {
-        create_lock_surface_for_all_monitors(lock);
-    } else {
-        // Error message already shown when handling the ::failed signal
-    }
+    gtk_session_lock_instance_lock(lock);
 }
 
-static void lock_button_callback(GtkWidget* button, void* data) {
+static void on_lock_button_clicked(GtkWidget* button, void* data) {
     (void)button;
     lock_display(data);
 }
 
-static void quit_button_callback(GtkWidget* button, void* data) {
+static void on_quit_button_clicked(GtkWidget* button, void* data) {
     (void)button;
     GtkSessionLockInstance* lock = data;
     if (gtk_session_lock_instance_is_locked(lock)) {
@@ -90,10 +77,10 @@ static void quit_button_callback(GtkWidget* button, void* data) {
 // Creates a normal GTK window with buttons to allow the user to re-lock the display or exit
 static void create_control_window(GtkSessionLockInstance* lock) {
     GtkWidget* lock_button = gtk_button_new_with_label("Lock");
-    g_signal_connect(lock_button, "clicked", G_CALLBACK(lock_button_callback), lock);
+    g_signal_connect(lock_button, "clicked", G_CALLBACK(on_lock_button_clicked), lock);
 
     GtkWidget* quit_button = gtk_button_new_with_label("Quit");
-    g_signal_connect(quit_button, "clicked", G_CALLBACK(quit_button_callback), lock);
+    g_signal_connect(quit_button, "clicked", G_CALLBACK(on_quit_button_clicked), lock);
 
     GtkWidget* box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
     gtk_widget_set_valign(box, GTK_ALIGN_START);
@@ -111,12 +98,12 @@ static void activate(GtkApplication* app, void *data) {
 
     // This creates the lock instance, but does not lock the display yet
     GtkSessionLockInstance* lock = gtk_session_lock_instance_new();
-    g_signal_connect(lock, "locked", G_CALLBACK(locked), NULL);
-    g_signal_connect(lock, "failed", G_CALLBACK(failed), NULL);
-    g_signal_connect(lock, "unlocked", G_CALLBACK(unlocked), NULL);
+    g_signal_connect(lock, "locked", G_CALLBACK(on_locked), lock);
+    g_signal_connect(lock, "failed", G_CALLBACK(on_failed), lock);
+    g_signal_connect(lock, "unlocked", G_CALLBACK(on_unlocked), lock);
+    g_signal_connect(lock, "monitor", G_CALLBACK(on_monitor), lock);
 
-    create_control_window(lock);
-
+    create_control_window(lock); // Won't work if called while display is locked
     lock_display(lock);
 }
 

--- a/examples/session-lock.py
+++ b/examples/session-lock.py
@@ -19,6 +19,7 @@ class ScreenLock:
         self.lock_instance.connect('locked', self._on_locked)
         self.lock_instance.connect('unlocked', self._on_unlocked)
         self.lock_instance.connect('failed', self._on_failed)
+        self.lock_instance.connect('monitor', self._on_monitor)
 
     def _on_locked(self, lock_instance):
         print('Locked!')
@@ -31,10 +32,7 @@ class ScreenLock:
         print('Failed to lock :(')
         app.quit()
 
-    def _on_unlock_clicked(self, button):
-        self.lock_instance.unlock()
-
-    def _create_lock_window(self, monitor):
+    def _on_monitor(self, lock_instance, monitor):
         window = Gtk.Window(application=app)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
@@ -50,17 +48,12 @@ class ScreenLock:
         box.append(button)
 
         self.lock_instance.assign_window_to_monitor(window, monitor)
-        window.present()
+
+    def _on_unlock_clicked(self, button):
+        self.lock_instance.unlock()
 
     def lock(self):
-        if not self.lock_instance.lock():
-            # Failure has already been handled in on_failed()
-            return
-
-        display = Gdk.Display.get_default()
-
-        for monitor in display.get_monitors():
-            self._create_lock_window(monitor)
+        self.lock_instance.lock()
 
 app = Gtk.Application(application_id='com.github.wmww.gtk4-layer-shell.py-session-lock')
 lock = ScreenLock()

--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -126,7 +126,7 @@ gboolean gtk_session_lock_instance_is_locked(GtkSessionLockInstance* self);
  * This must be called with a different unrealized window once for each monitor immediately after calling
  * gtk_session_lock_lock(). Hiding a window that is active on a monitor or not letting a window be resized by the
  * library is not allowed (may result in a Wayland protocol error). The window will be unmapped and gtk_window_destroy()
- * called on it when the current lock ends, but you can continue to use it if you hold a strong reference.
+ * called on it when the current lock ends.
  */
 void gtk_session_lock_instance_assign_window_to_monitor(
     GtkSessionLockInstance* self,

--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -46,19 +46,36 @@ GTK4_LAYER_SHELL_EXPORT
 G_DECLARE_FINAL_TYPE(GtkSessionLockInstance, gtk_session_lock_instance, GTK_SESSION_LOCK, INSTANCE, GObject)
 
 /**
+ * GtkSessionLockInstance::monitor:
+ * @self: the #GtkSessionLockInstance
+ * @monitor: the #GdkMonitor that exists or was added
+ *
+ * The ::monitor signal is fired once for each monitor that exists when a lock is started, and then whenever a new
+ * monitor is detected during the lock. You generally want to call gtk_session_lock_instance_assign_window_to_monitor()
+ * once in the handler for this signal with a newly created window and the given monitor.
+ *
+ * This API does not directly tell you when a monitor is removed (GTK APIs can be used for that), however the window you
+ * send to gtk_session_lock_instance_assign_window_to_monitor() will be automatically unmapped and dereferenced when its
+ * monitor is removed or the screen is unlocked.
+ */
+
+/**
  * GtkSessionLockInstance::locked:
+ * @self: the #GtkSessionLockInstance
  *
  * The ::locked signal is fired when the screen is successfully locked.
  */
 
 /**
  * GtkSessionLockInstance::failed:
+ * @self: the #GtkSessionLockInstance
  *
  * The ::failed signal is fired when the lock could not be acquired.
  */
 
 /**
  * GtkSessionLockInstance::unlocked:
+ * @self: the #GtkSessionLockInstance
  *
  * The ::unlocked signal is fired when the session is unlocked, which may have been caused by a call to
  * gtk_session_lock_instance_unlock() or by the compositor.

--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -41,6 +41,8 @@ gboolean gtk_session_lock_is_supported();
  *
  * An instance of the object used to control locking the screen.
  * Multiple instances can exist at once, but only one can be locked at a time.
+ *
+ * Since: 1.1
  */
 GTK4_LAYER_SHELL_EXPORT
 G_DECLARE_FINAL_TYPE(GtkSessionLockInstance, gtk_session_lock_instance, GTK_SESSION_LOCK, INSTANCE, GObject)
@@ -57,6 +59,8 @@ G_DECLARE_FINAL_TYPE(GtkSessionLockInstance, gtk_session_lock_instance, GTK_SESS
  * This API does not directly tell you when a monitor is removed (GTK APIs can be used for that), however the window you
  * send to gtk_session_lock_instance_assign_window_to_monitor() will be automatically unmapped and dereferenced when its
  * monitor is removed or the screen is unlocked.
+ *
+ * Since: 1.2
  */
 
 /**

--- a/include/gtk4-session-lock.h
+++ b/include/gtk4-session-lock.h
@@ -123,10 +123,10 @@ gboolean gtk_session_lock_instance_is_locked(GtkSessionLockInstance* self);
  * @window: The GTK Window to use as a lock surface
  * @monitor: (not nullable): The monitor to show it on
  *
- * This must be called with a different window once for each monitor immediately after calling gtk_session_lock_lock().
- * Hiding a window that is active on a monitor or not letting a window be resized by the library is not allowed (may
- * result in a Wayland protocol error). The window will be unmapped and gtk_window_destroy() called on it when the
- * current lock ends, but you can continue to use it if you hold a strong reference.
+ * This must be called with a different unrealized window once for each monitor immediately after calling
+ * gtk_session_lock_lock(). Hiding a window that is active on a monitor or not letting a window be resized by the
+ * library is not allowed (may result in a Wayland protocol error). The window will be unmapped and gtk_window_destroy()
+ * called on it when the current lock ends, but you can continue to use it if you hold a strong reference.
  */
 void gtk_session_lock_instance_assign_window_to_monitor(
     GtkSessionLockInstance* self,

--- a/src/gtk4-layer-shell.c
+++ b/src/gtk4-layer-shell.c
@@ -252,7 +252,7 @@ static void gtk_layer_surface_monitor_invalidated(GdkMonitor* self, struct gtk_l
 static void gtk_layer_surface_clear_monitor(struct gtk_layer_surface_t* layer_surface) {
     if (layer_surface->monitor) {
         g_signal_handlers_disconnect_by_data(layer_surface->monitor, layer_surface);
-        g_object_unref(G_OBJECT(layer_surface->monitor));
+        g_clear_object(&layer_surface->monitor);
     }
 }
 
@@ -267,9 +267,8 @@ void gtk_layer_set_monitor(GtkWindow* window, GdkMonitor* monitor) {
         g_return_if_fail(output);
     }
     gtk_layer_surface_clear_monitor(layer_surface);
-    layer_surface->monitor = monitor;
+    layer_surface->monitor = monitor ? g_object_ref(monitor) : NULL;
     if (monitor) {
-        g_object_ref(G_OBJECT(monitor));
         // Connect after hopefully allows apps to handle this first
         g_signal_connect_after(monitor, "invalidate",  G_CALLBACK(gtk_layer_surface_monitor_invalidated), layer_surface);
     }

--- a/src/gtk4-session-lock.c
+++ b/src/gtk4-session-lock.c
@@ -281,8 +281,9 @@ void gtk_session_lock_instance_assign_window_to_monitor(
 
     gtk_window_set_decorated(window, FALSE);
 
-    if (gtk_widget_get_mapped(GTK_WIDGET(window))) {
-        gtk_widget_unrealize(GTK_WIDGET(window));
-        gtk_widget_map(GTK_WIDGET(window));
+    if (gtk_widget_get_realized(GTK_WIDGET(window))) {
+        g_critical("gtk_session_lock_instance_assign_window_to_monitor() should not be called with an already realized window");
     }
+
+    gtk_window_present(window);
 }

--- a/test/README.md
+++ b/test/README.md
@@ -2,14 +2,32 @@
 This directory is home to the gtk4-layer-shell test suite.
 
 ## To run tests
-`ninja -C build test` (where `build` is the path to your build directory).
-
-### To run a single test
+```bash
+ninja -C build test
 ```
-meson test -C build --verbose [testname]
+(where `build` is the path to your build directory).
+
+To run a single test:
+```bash
+ninja -C build && meson test -C build --verbose [testname]
 ```
 
-If you want to run the test client and server separately (for example, to run either in `wayland-debug`):
+To run against the current Wayland compositor:
+```bash
+ninja -C build && ./build/test/<testname> --auto
+```
+This can help with debugging since you get to see the output.
+
+Don't run the session lock tests this way unless you know what you're doing. Some of them may soft-brick your compositor. If this happens you may need to reboot.
+
+You can drop the `--auto` flag to run the test interactively, so you can click through each section.
+
+To run under [wayland-debug](https://github.com/wmww/wayland-debug):
+```bash
+ninja -C build && wayland-debug -f 'zwlr_*, xdg_*, ext_*' -r ./build/test/<testname> --auto
+```
+
+To run under the mock server, but separately:
 ```bash
 # server:
 ninja -C build && GTKLS_TEST_DIR=/tmp ./build/test/mock-server/mock-server

--- a/test/integration-test-common/integration-test-common.c
+++ b/test/integration-test-common/integration-test-common.c
@@ -55,6 +55,7 @@ void send_command(const char* command, const char* expected_response) {
         ASSERT(bytes_read > 0);
         if (*c == '\n') {
             *c = '\0';
+            fprintf(stderr, "got: %s\n", buffer);
             ASSERT_STR_EQ(buffer, expected_response);
             break;
         } else {

--- a/test/integration-test-common/integration-test-common.c
+++ b/test/integration-test-common/integration-test-common.c
@@ -121,7 +121,6 @@ static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor* monitor, void* 
     (void)data;
     GtkWindow* window = create_default_window();
     gtk_session_lock_instance_assign_window_to_monitor(lock, window, monitor);
-    gtk_window_present(window);
 }
 
 void connect_lock_signals_except_monitor(GtkSessionLockInstance* lock, enum lock_state_t* state) {

--- a/test/integration-test-common/integration-test-common.h
+++ b/test/integration-test-common/integration-test-common.h
@@ -37,8 +37,7 @@ enum lock_state_t {
     LOCK_STATE_LOCKED,
     LOCK_STATE_FAILED,
 };
+void connect_lock_signals_except_monitor(GtkSessionLockInstance* lock, enum lock_state_t* state);
 void connect_lock_signals(GtkSessionLockInstance* lock, enum lock_state_t* state);
-void create_lock_windows(GtkSessionLockInstance* lock, GtkWindow* (*builder)());
-void create_default_lock_windows(GtkSessionLockInstance* lock);
 
 #endif // TEST_CLIENT_COMMON_H

--- a/test/layer-tests/meson.build
+++ b/test/layer-tests/meson.build
@@ -31,6 +31,7 @@ layer_tests = [
     'test-get-keyboard-mode',
     'test-get-monitor',
     'test-set-monitor',
+    'test-monitor-removed',
     'test-create-xdg-toplevel',
     'test-hide-and-show',
     'test-init-after-window-created',

--- a/test/layer-tests/test-monitor-removed.c
+++ b/test/layer-tests/test-monitor-removed.c
@@ -1,0 +1,27 @@
+#include "integration-test-common.h"
+
+static GtkWindow* window;
+
+static void callback_0() {
+    send_command("create_output 640 480", "output_created");
+
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface wl_output);
+    window = create_default_window();
+    gtk_layer_init_for_window(window);
+    for (int i = 0; i < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER; i++) gtk_layer_set_anchor(window, i, TRUE);
+    ASSERT_EQ(g_list_model_get_n_items(gdk_display_get_monitors(gdk_display_get_default())), 2, "%d");
+    GdkMonitor *monitor = g_list_model_get_item(gdk_display_get_monitors(gdk_display_get_default()), 1);
+    ASSERT(GDK_IS_MONITOR(monitor));
+    gtk_layer_set_monitor(window, monitor);
+    gtk_window_present(window);
+}
+
+static void callback_1() {
+    EXPECT_MESSAGE(zwlr_layer_shell_v1 .get_layer_surface nil);
+    send_command("destroy_output 1", "output_destroyed");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+)

--- a/test/lock-tests/meson.build
+++ b/test/lock-tests/meson.build
@@ -5,6 +5,7 @@ lock_tests = [
     'test-can-reuse-lock-window',
     'test-multiple-monitors',
     'test-monitors-changed-while-locked',
+    'test-monitors-changed-after-unlocked',
     'test-immediate-failure',
     'test-async-failure',
     'test-popup-on-lock-screen',

--- a/test/lock-tests/meson.build
+++ b/test/lock-tests/meson.build
@@ -3,6 +3,8 @@ lock_tests = [
     'test-can-lock-display',
     'test-can-relock-display',
     'test-can-reuse-lock-window',
+    'test-multiple-monitors',
+    'test-monitors-changed-while-locked',
     'test-immediate-failure',
     'test-async-failure',
     'test-popup-on-lock-screen',

--- a/test/lock-tests/meson.build
+++ b/test/lock-tests/meson.build
@@ -6,4 +6,5 @@ lock_tests = [
     'test-immediate-failure',
     'test-async-failure',
     'test-popup-on-lock-screen',
+    'test-works-without-monitor-signal',
 ]

--- a/test/lock-tests/test-async-failure.c
+++ b/test/lock-tests/test-async-failure.c
@@ -54,9 +54,8 @@ static void callback_1() {
     lock = gtk_session_lock_instance_new();
     connect_lock_signals(lock, &state);
 
-    ASSERT(gtk_session_lock_instance_lock(lock));
-    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
-    create_default_lock_windows(lock);
+    // This may return true or false depending on if the monitor signal handler roundtrips
+    gtk_session_lock_instance_lock(lock);
 }
 
 static void callback_2() {

--- a/test/lock-tests/test-can-relock-display.c
+++ b/test/lock-tests/test-can-relock-display.c
@@ -16,7 +16,6 @@ static void callback_0() {
     ASSERT(!gtk_session_lock_instance_is_locked(lock_a));
 
     ASSERT(gtk_session_lock_instance_lock(lock_a));
-    create_default_lock_windows(lock_a);
 }
 
 static void callback_1() {
@@ -37,7 +36,6 @@ static void callback_1() {
     EXPECT_MESSAGE(ext_session_lock_v1 .locked);
 
     ASSERT(gtk_session_lock_instance_lock(lock_a));
-    create_default_lock_windows(lock_a);
 }
 
 static void callback_2() {
@@ -61,7 +59,6 @@ static void callback_2() {
     connect_lock_signals(lock_b, &state_b);
 
     ASSERT(gtk_session_lock_instance_lock(lock_b));
-    create_default_lock_windows(lock_b);
 }
 
 static void callback_3() {

--- a/test/lock-tests/test-can-reuse-lock-window.c
+++ b/test/lock-tests/test-can-reuse-lock-window.c
@@ -4,8 +4,10 @@ enum lock_state_t state = 0;
 GtkSessionLockInstance* lock = NULL;
 GtkWindow* lock_window = NULL;
 
-static GtkWindow* get_lock_window() {
-    return lock_window;
+static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor* monitor, void* data) {
+    (void)lock; (void)monitor; (void)data;
+    gtk_session_lock_instance_assign_window_to_monitor(lock, lock_window, monitor);
+    gtk_window_present(lock_window);
 }
 
 static void callback_0() {
@@ -16,11 +18,11 @@ static void callback_0() {
     lock_window = g_object_ref(create_default_window());
 
     lock = gtk_session_lock_instance_new();
-    connect_lock_signals(lock, &state);
+    connect_lock_signals_except_monitor(lock, &state);
+    g_signal_connect(lock, "monitor", G_CALLBACK(on_monitor), NULL);
     ASSERT(!gtk_session_lock_instance_is_locked(lock));
 
     ASSERT(gtk_session_lock_instance_lock(lock));
-    create_lock_windows(lock, get_lock_window);
 }
 
 static void callback_1() {
@@ -41,7 +43,6 @@ static void callback_2() {
     EXPECT_MESSAGE(ext_session_lock_v1 .locked);
     ASSERT(gtk_session_lock_instance_lock(lock));
     fprintf(stderr, "\nlock window: %p\n\n", lock_window);
-    create_lock_windows(lock, get_lock_window);
     fprintf(stderr, "\nlock windows created\n\n");
 }
 

--- a/test/lock-tests/test-can-reuse-lock-window.c
+++ b/test/lock-tests/test-can-reuse-lock-window.c
@@ -7,7 +7,6 @@ GtkWindow* lock_window = NULL;
 static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor* monitor, void* data) {
     (void)lock; (void)monitor; (void)data;
     gtk_session_lock_instance_assign_window_to_monitor(lock, lock_window, monitor);
-    gtk_window_present(lock_window);
 }
 
 static void callback_0() {

--- a/test/lock-tests/test-immediate-failure.c
+++ b/test/lock-tests/test-immediate-failure.c
@@ -19,7 +19,6 @@ static void callback_0() {
 
     ASSERT(gtk_session_lock_instance_lock(lock_b));
     ASSERT(!gtk_session_lock_instance_lock(lock_b));
-    create_default_lock_windows(lock_b);
 }
 
 static void callback_1() {

--- a/test/lock-tests/test-monitors-changed-after-unlocked.c
+++ b/test/lock-tests/test-monitors-changed-after-unlocked.c
@@ -1,0 +1,52 @@
+#include "integration-test-common.h"
+
+enum lock_state_t state = 0;
+GtkSessionLockInstance* lock;
+
+static void callback_0() {
+    EXPECT_MESSAGE(ext_session_lock_manager_v1 .lock);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1920 1080);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 640 480);
+
+    send_command("create_output 640 480", "output_created");
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals(lock, &state);
+
+    ASSERT(gtk_session_lock_instance_lock(lock));
+}
+
+static void callback_1() {
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1080 720);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .ack_configure);
+
+    send_command("create_output 1080 720", "output_created");
+}
+
+static void callback_2() {
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    gtk_session_lock_instance_unlock(lock);
+}
+
+static void callback_3() {
+    send_command("destroy_output 2", "output_destroyed");
+    send_command("destroy_output 0", "output_destroyed");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+    callback_3,
+)

--- a/test/lock-tests/test-monitors-changed-while-locked.c
+++ b/test/lock-tests/test-monitors-changed-while-locked.c
@@ -1,0 +1,64 @@
+#include "integration-test-common.h"
+
+enum lock_state_t state = 0;
+GtkSessionLockInstance* lock;
+
+static void callback_0() {
+    EXPECT_MESSAGE(ext_session_lock_manager_v1 .lock);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1920 1080);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 640 480);
+
+    send_command("create_output 640 480", "output_created");
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals(lock, &state);
+
+    ASSERT(gtk_session_lock_instance_lock(lock));
+}
+
+static void callback_1() {
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1080 720);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .ack_configure);
+
+    send_command("create_output 1080 720", "output_created");
+}
+
+static void callback_2() {
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    send_command("destroy_output 0", "output_destroyed");
+}
+
+static void callback_3() {
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    send_command("destroy_output 2", "output_destroyed");
+}
+
+static void callback_4() {
+    EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .destroy);
+    EXPECT_MESSAGE(wl_surface .destroy);
+
+    gtk_session_lock_instance_unlock(lock);
+}
+
+static void callback_5() {
+    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+    callback_3,
+    callback_4,
+    callback_5,
+)

--- a/test/lock-tests/test-multiple-monitors.c
+++ b/test/lock-tests/test-multiple-monitors.c
@@ -1,0 +1,39 @@
+#include "integration-test-common.h"
+
+enum lock_state_t state = 0;
+GtkSessionLockInstance* lock;
+
+static void callback_0() {
+    EXPECT_MESSAGE(ext_session_lock_manager_v1 .lock);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1920 1080);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 640 480);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_surface_v1 .configure 1080 720);
+
+    send_command("create_output 640 480", "output_created");
+    send_command("create_output 1080 720", "output_created");
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals(lock, &state);
+
+    ASSERT(gtk_session_lock_instance_lock(lock));
+}
+
+static void callback_1() {
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+    EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
+
+    gtk_session_lock_instance_unlock(lock);
+}
+
+static void callback_2() {
+    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+)

--- a/test/lock-tests/test-popup-on-lock-screen.c
+++ b/test/lock-tests/test-popup-on-lock-screen.c
@@ -6,11 +6,13 @@ GtkWindow* window;
 static GtkWidget *dropdown;
 static const char *options[] = {"Foo", "Bar", "Baz", NULL};
 
-GtkWindow* build_window() {
+static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor* monitor, void* data) {
+    (void)lock; (void)monitor; (void)data;
     window = GTK_WINDOW(gtk_window_new());
     dropdown = gtk_drop_down_new_from_strings(options);
     gtk_window_set_child(window, dropdown);
-    return window;
+    gtk_session_lock_instance_assign_window_to_monitor(lock, window, monitor);
+    gtk_window_present(window);
 }
 
 static void callback_0() {
@@ -18,10 +20,10 @@ static void callback_0() {
     step_time = 1200;
 
     lock = gtk_session_lock_instance_new();
-    connect_lock_signals(lock, &state);
+    connect_lock_signals_except_monitor(lock, &state);
+    g_signal_connect(lock, "monitor", G_CALLBACK(on_monitor), NULL);
 
     ASSERT(gtk_session_lock_instance_lock(lock));
-    create_lock_windows(lock, build_window);
 }
 
 static void callback_1() {

--- a/test/lock-tests/test-popup-on-lock-screen.c
+++ b/test/lock-tests/test-popup-on-lock-screen.c
@@ -12,7 +12,6 @@ static void on_monitor(GtkSessionLockInstance* lock, GdkMonitor* monitor, void* 
     dropdown = gtk_drop_down_new_from_strings(options);
     gtk_window_set_child(window, dropdown);
     gtk_session_lock_instance_assign_window_to_monitor(lock, window, monitor);
-    gtk_window_present(window);
 }
 
 static void callback_0() {

--- a/test/lock-tests/test-works-without-monitor-signal.c
+++ b/test/lock-tests/test-works-without-monitor-signal.c
@@ -9,24 +9,23 @@ static void callback_0() {
     EXPECT_MESSAGE(ext_session_lock_v1 .locked);
 
     lock = gtk_session_lock_instance_new();
-    connect_lock_signals(lock, &state);
-
+    connect_lock_signals_except_monitor(lock, &state);
     ASSERT(gtk_session_lock_instance_lock(lock));
+    GListModel* monitors = gdk_display_get_monitors(gdk_display_get_default());
+    ASSERT_EQ(g_list_model_get_n_items(monitors), 1, "%d");
+    GdkMonitor* monitor = g_list_model_get_item(monitors, 0);
+    GtkWindow* window = create_default_window();
+    gtk_session_lock_instance_assign_window_to_monitor(lock, window, monitor);
+    gtk_window_present(window);
 }
 
 static void callback_1() {
     ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
     EXPECT_MESSAGE(ext_session_lock_v1 .unlock_and_destroy);
-
     gtk_session_lock_instance_unlock(lock);
-}
-
-static void callback_2() {
-    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
 }
 
 TEST_CALLBACKS(
     callback_0,
     callback_1,
-    callback_2,
 )

--- a/test/lock-tests/test-works-without-monitor-signal.c
+++ b/test/lock-tests/test-works-without-monitor-signal.c
@@ -16,6 +16,8 @@ static void callback_0() {
     GdkMonitor* monitor = g_list_model_get_item(monitors, 0);
     GtkWindow* window = create_default_window();
     gtk_session_lock_instance_assign_window_to_monitor(lock, window, monitor);
+
+    // This isn't needed, but it was recommend in an earlier version of the library so we test that it works
     gtk_window_present(window);
 }
 


### PR DESCRIPTION
The ::monitor signal makes it easy to create a new window for each monitor as needed, including dynamically added monitors. This PR also adds the ability to test multi-monitor setups with the mock server, which I've been meaning to do for a while.