### PR TITLE
Fix use-after-free when destroying lock windows owned by a GtkApplica…

### DIFF
--- a/src/gtk4-session-lock.c
+++ b/src/gtk4-session-lock.c
@@ -219,19 +219,15 @@ static void gtk_lock_surface_unmap_window(struct gtk_lock_surface_t* self) {
     if (!window) return;
     self->gtk_window = NULL;
     g_signal_handlers_disconnect_by_data(window, self);
-    // Hold a reference so the realized check below is safe if gtk_window_destroy() dropped the last one.
+    // Hold a reference so the realized check is safe after destroy
     g_object_ref(window);
-    // This destroys GTK's internal reference to the window, the program could still be holding a reference to the
-    // window if it wants to keep it alive and use it again. It must be called while the window is still realized:
-    // it removes the window from its GtkApplication (if any), and gtk_application_window_removed() uses the window's
-    // GdkSurface on GTK >= 4.22, so unrealizing first is a use-after-free crash. See
-    // https://github.com/wmww/gtk4-layer-shell/issues/122 for details.
+    // We want to destroy the window if the user holds no other references to it, and unrealize it in all cases. Destroy
+    // does not seem to unmap unless the final reference is being destroyed, and unrealizing first seems to trigger a
+    // GTK bug on some GTK versions, thus we grab a ref so we can safely unrealize after destroy. I reccomend running
+    // the tests with GTKLS_VALGRIND=1 if you mess with this code.
+    // See https://github.com/wmww/gtk4-layer-shell/issues/122 and https://github.com/wmww/gtk4-layer-shell/pull/99
     gtk_window_destroy(window);
-    // gtk_window_destroy() does nothing on a window that was already destroyed (such as an externally referenced
-    // window being reused for a second lock), so explicitly unrealize to make sure the surface is torn down.
-    if (gtk_widget_get_realized(GTK_WIDGET(window))) {
-        gtk_widget_unrealize(GTK_WIDGET(window));
-    }
+    gtk_widget_unrealize(GTK_WIDGET(window));
     g_object_unref(window);
 }
 

--- a/src/gtk4-session-lock.c
+++ b/src/gtk4-session-lock.c
@@ -219,10 +219,20 @@ static void gtk_lock_surface_unmap_window(struct gtk_lock_surface_t* self) {
     if (!window) return;
     self->gtk_window = NULL;
     g_signal_handlers_disconnect_by_data(window, self);
-    gtk_widget_unrealize(GTK_WIDGET(window));
+    // Hold a reference so the realized check below is safe if gtk_window_destroy() dropped the last one.
+    g_object_ref(window);
     // This destroys GTK's internal reference to the window, the program could still be holding a reference to the
-    // window if it wants to keep it alive and use it again.
+    // window if it wants to keep it alive and use it again. It must be called while the window is still realized:
+    // it removes the window from its GtkApplication (if any), and gtk_application_window_removed() uses the window's
+    // GdkSurface on GTK >= 4.22, so unrealizing first is a use-after-free crash. See
+    // https://github.com/wmww/gtk4-layer-shell/issues/122 for details.
     gtk_window_destroy(window);
+    // gtk_window_destroy() does nothing on a window that was already destroyed (such as an externally referenced
+    // window being reused for a second lock), so explicitly unrealize to make sure the surface is torn down.
+    if (gtk_widget_get_realized(GTK_WIDGET(window))) {
+        gtk_widget_unrealize(GTK_WIDGET(window));
+    }
+    g_object_unref(window);
 }
 
 static gint find_lock_surface_with_wl_surface(gconstpointer lock_surface, gconstpointer needle) {

--- a/test/lock-tests/meson.build
+++ b/test/lock-tests/meson.build
@@ -8,6 +8,8 @@ lock_tests = [
     'test-monitors-changed-after-unlocked',
     'test-immediate-failure',
     'test-async-failure',
+    'test-async-failure-application-window',
     'test-popup-on-lock-screen',
     'test-works-without-monitor-signal',
+    'test-can-unlock-application-window',
 ]

--- a/test/lock-tests/test-async-failure-application-window.c
+++ b/test/lock-tests/test-async-failure-application-window.c
@@ -1,0 +1,86 @@
+#include "integration-test-common.h"
+
+#include "ext-session-lock-v1-client.h"
+
+// Same as test-async-failure, but the lock window is owned by a GtkApplication. The rejection's `finished` event is
+// dispatched during the assign/present roundtrip, tearing the window down mid-present; destroying an application
+// window must happen while it is still realized on GTK >= 4.22 (see test-can-unlock-application-window.c), so this
+// crashed with a use-after-free when the teardown unrealized first.
+
+enum lock_state_t state = 0;
+struct ext_session_lock_manager_v1* global;
+GtkApplication* app;
+GtkSessionLockInstance* lock;
+
+static void wl_registry_handle_global(
+    void* _data,
+    struct wl_registry* registry,
+    uint32_t id,
+    const char* interface,
+    uint32_t version
+) {
+    (void)_data;
+
+    if (strcmp(interface, ext_session_lock_manager_v1_interface.name) == 0) {
+        global = wl_registry_bind(registry, id, &ext_session_lock_manager_v1_interface, version);
+    }
+}
+
+static void wl_registry_handle_global_remove(void* _data, struct wl_registry* _registry, uint32_t _id) {
+    (void)_data;
+    (void)_registry;
+    (void)_id;
+}
+
+static const struct wl_registry_listener wl_registry_listener = {
+    .global = wl_registry_handle_global,
+    .global_remove = wl_registry_handle_global_remove,
+};
+
+static void bind_global(struct wl_display* display) {
+    struct wl_registry* registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &wl_registry_listener, NULL);
+    wl_display_roundtrip(display);
+    wl_registry_destroy(registry);
+}
+
+static void on_monitor(GtkSessionLockInstance* lock_, GdkMonitor* monitor, void* data) {
+    (void)data;
+    GtkWindow* window = GTK_WINDOW(gtk_application_window_new(app));
+    gtk_window_set_child(window, gtk_label_new("locked"));
+    gtk_session_lock_instance_assign_window_to_monitor(lock_, window, monitor);
+}
+
+static void callback_0() {
+    // We lock the display without going through the library in order to simulate a lock being held by another process
+    bind_global(gdk_wayland_display_get_wl_display(gdk_display_get_default()));
+    ASSERT(global);
+    struct ext_session_lock_v1* session_lock = ext_session_lock_manager_v1_lock(global);
+    (void)session_lock;
+}
+
+static void callback_1() {
+    EXPECT_MESSAGE(ext_session_lock_manager_v1 .lock);
+    EXPECT_MESSAGE(ext_session_lock_v1 .get_lock_surface);
+    EXPECT_MESSAGE(ext_session_lock_v1 .finished);
+
+    app = gtk_application_new("com.github.wmww.gtk4-layer-shell.test", G_APPLICATION_DEFAULT_FLAGS);
+    ASSERT(g_application_register(G_APPLICATION(app), NULL, NULL));
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals_except_monitor(lock, &state);
+    g_signal_connect(lock, "monitor", G_CALLBACK(on_monitor), NULL);
+
+    // This may return true or false depending on if the monitor signal handler roundtrips
+    gtk_session_lock_instance_lock(lock);
+}
+
+static void callback_2() {
+    ASSERT_EQ(state, LOCK_STATE_FAILED, "%d");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+)

--- a/test/lock-tests/test-can-unlock-application-window.c
+++ b/test/lock-tests/test-can-unlock-application-window.c
@@ -1,0 +1,43 @@
+#include "integration-test-common.h"
+
+// Regression test for https://github.com/wmww/gtk4-layer-shell/issues/122
+// Unlike the other lock tests, the lock window here is owned by a GtkApplication. Destroying such a window emits
+// GtkApplication::window-removed, and on GTK >= 4.22 gtk_application_window_removed() uses the window's GdkSurface
+// (for XDG session management), so the window must still be realized when gtk_window_destroy() is called.
+// Unrealizing it first crashed with a use-after-free on every unlock or lock failure.
+
+enum lock_state_t state = 0;
+GtkApplication* app;
+GtkSessionLockInstance* lock;
+
+static void on_monitor(GtkSessionLockInstance* lock_, GdkMonitor* monitor, void* data) {
+    (void)data;
+    GtkWindow* window = GTK_WINDOW(gtk_application_window_new(app));
+    gtk_window_set_child(window, gtk_label_new("locked"));
+    gtk_session_lock_instance_assign_window_to_monitor(lock_, window, monitor);
+}
+
+static void callback_0() {
+    app = gtk_application_new("com.github.wmww.gtk4-layer-shell.test", G_APPLICATION_DEFAULT_FLAGS);
+    ASSERT(g_application_register(G_APPLICATION(app), NULL, NULL));
+
+    lock = gtk_session_lock_instance_new();
+    connect_lock_signals_except_monitor(lock, &state);
+    g_signal_connect(lock, "monitor", G_CALLBACK(on_monitor), NULL);
+    ASSERT(gtk_session_lock_instance_lock(lock));
+}
+
+static void callback_1() {
+    ASSERT_EQ(state, LOCK_STATE_LOCKED, "%d");
+    gtk_session_lock_instance_unlock(lock);
+}
+
+static void callback_2() {
+    ASSERT_EQ(state, LOCK_STATE_UNLOCKED, "%d");
+}
+
+TEST_CALLBACKS(
+    callback_0,
+    callback_1,
+    callback_2,
+)


### PR DESCRIPTION
  Fixes #122

  ## The bug

  `gtk_lock_surface_unmap_window()` unrealizes the window before calling
  `gtk_window_destroy()`. For windows created with `gtk_application_window_new()`,
  the destroy emits `GtkApplication::window-removed`, and since GTK 4.22
  `gtk_application_window_removed()` uses the window's `GdkSurface` (for XDG
  session management support). The unrealize has already destroyed that surface,
  so the handler reads a dead pointer:

  ```
  (process): Gdk-CRITICAL: gdk_surface_get_display: assertion 'GDK_IS_SURFACE (surface)' failed
  <SIGSEGV>
  ```

  This crashes **every unlock and every lock failure** for clients using
  application windows — including the bundled `examples/session-lock.c` and
  `session-lock.py`, which is what #122 is reporting. Nothing in this library
  changed; GTK 4.22 made the existing teardown ordering fatal. That matches the
  #122 reporter first seeing it after a routine distro upgrade.

  Backtrace with debug symbols (unlock path; the lock-failure path crashes at the
  same site via `session_lock_locked_callback_impl` → `clear_lock_state`):

  ```
  #0  gdk_wayland_toplevel_remove_from_session ()          libgtk-4.so.1 (4.22.4)
  #1  gtk_application_window_removed ()                    libgtk-4.so.1
  ...
  #7  gtk_window_destroy ()                                libgtk-4.so.1
  #8  gtk_lock_surface_unmap_window  src/gtk4-session-lock.c:225
  #9  clear_lock_state               src/gtk4-session-lock.c:117
  #10 gtk_session_lock_instance_unlock  src/gtk4-session-lock.c:197
  ```

  The kernel-reported fault is a NULL deref at offset 0x278:
  `gdk_surface_get_display` fails its assertion, returns NULL, and
  `gdk_wayland_toplevel_remove_from_session` dereferences the NULL display.

  The existing lock tests don't catch this because they all create bare
  `gtk_window_new()` windows, which are never added to a GtkApplication, so
  `window-removed` never fires.

  ## The fix

  Destroy first, then unrealize only if the window is still realized:

  * `gtk_window_destroy()` must run while the window is still realized, because it
    removes the window from its application before unrealizing — the order GTK
    itself relies on.
  * The explicit unrealize (added in fac7be1) is still needed afterwards:
    `gtk_window_destroy()` does nothing on a window that was already destroyed,
    such as an externally referenced window being reused for a second lock.
    Dropping the unrealize entirely regresses `lock-test-can-reuse-lock-window`
    (the second unlock never destroys the `wl_surface`).
  * The window is referenced across the call so the realized check is safe if
    destroy dropped the last reference — same pattern as #109.

  ## Tests

  Two regression tests, both verified to SIGSEGV without the fix and pass with it:

  * `lock-test-can-unlock-application-window` — plain unlock of an
    application-window lock surface (the #122 scenario).
  * `lock-test-async-failure-application-window` — `test-async-failure` with an
    application window: the rejection's `finished` arrives during the
    assign/present roundtrip and tears the window down mid-present (this is how
    real lock screens hit it on resume from suspend, when the compositor refuses
    the lock).

  Note: the tests only exercise the bug when built against GTK >= 4.22; on older
  GTK they pass with or without the fix (the surface-using code in
  `gtk_application_window_removed()` doesn't exist there).

  ## Validation

  * Full meson test suite passes (GTK 4.22.4).
  * The four session-lock teardown tests (the two new ones, plus
    `can-reuse-lock-window` and `can-relock-display`) pass under valgrind with
    `--exit-on-first-error=yes`.
  * Reproduced and confirmed fixed outside the mock harness against sway 1.11
    (headless) with a second client pre-holding the session lock, and against a
    real GTK4 lock screen application that was crashing on resume from suspend
    with this exact signature.