### PR TITLE
layer-surface: clear any stale buffer when creating the layer surface

### DIFF
--- a/src/layer-surface.c
+++ b/src/layer-surface.c
@@ -283,6 +283,31 @@ static void layer_surface_create_surface_object(struct layer_surface_t* self, st
 
     const char* name_space = layer_surface_get_namespace(self);
 
+    // A wl_surface can outlive the layer surface built on it: GTK keeps one
+    // wl_surface across hide/show and tears down only the role object, so this
+    // function frequently runs on a surface that was previously mapped. Since
+    // wl_surface state is persistent, a buffer that was current when the
+    // previous layer surface was destroyed is still current here.
+    //
+    // This has to be cleared BEFORE the role is created. The protocol is
+    // explicit: "Creating a layer surface from a wl_surface which has a buffer
+    // attached or committed is a client error, and any attempts by a client to
+    // attach or manipulate a buffer prior to the first layer_surface.configure
+    // call must also be treated as errors." Clearing after get_layer_surface
+    // would be too late (role creation has already violated the rule) and
+    // would itself violate the second half of that sentence.
+    //
+    // The previous layer_surface role object was destroyed at unmap. The
+    // wl_surface retains that role for its lifetime, but creating the same role
+    // again is allowed; before the new role object exists, attach+commit is
+    // legal here and matches gdk_wayland_surface_hide_surface().
+    // The commit is required: attach alone only sets pending state and would
+    // not clear the CURRENT buffer. On a genuinely fresh surface this is a
+    // no-op, since attaching a null buffer to a surface that has none changes
+    // nothing.
+    wl_surface_attach(wl_surface, NULL, 0, 0);
+    wl_surface_commit(wl_surface);
+
     self->has_initial_layer_shell_configure = false;
     self->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
         layer_shell_global,


### PR DESCRIPTION
## The bug

A `wl_surface` can outlive the layer surface built on it. GTK keeps one `wl_surface` across hide/show and tears down only the role object, so `layer_surface_create_surface_object()` frequently runs on a surface that was previously mapped. `wl_surface` state is persistent, so a buffer that was current when the previous layer surface was destroyed is **still current** at that point.

The protocol requires the first commit after `get_layer_surface` to carry no buffer. If anything attached one in between, that initial commit carries it and the compositor kills the client:

```
zwlr_layer_surface_v1 error 2: "layer_surface has never been configured"
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

From `WAYLAND_DEBUG=1`, a working cycle vs a crashing one in the same session:

```
working  (#77 -> #64)          crashing (#64 -> #82)
destroy()                      destroy()
attach(nil); commit()          attach(nil); commit()
<nothing>                      attach(wl_buffer#79); commit()   <-- stray
get_layer_surface(#64)         get_layer_surface(#82)
commit() -> configure OK       commit() -> ERROR 2
```

The only difference is a frame queued by a closing animation landing ~0.7 ms after the unmap.

## This isn't GTK failing to clean up

I checked before assuming. `gdk_wayland_surface_hide_surface()` in GTK 4.22 already calls `gdk_wayland_surface_clear_frame_callback()` and then `wl_surface_attach(NULL)` + `wl_surface_commit()` — that's the `attach(nil); commit()` visible in *both* traces. The stray attach arrives after all of it. GTK destroys the `wl_surface` only on destroy, not on hide, so surface reuse across hide/show is deliberate GTK behaviour rather than an oversight.

That leaves the gap on the library side: a new role object gets created over a surface whose buffer state nobody re-cleared.

## The change

`wl_surface_attach(wl_surface, NULL, 0, 0)` + `wl_surface_commit()` immediately **before** `get_layer_surface`.

Placement matters, and the protocol is explicit about it:

> Creating a layer surface from a wl_surface which has a buffer attached or committed is a client error, and any attempts by a client to attach or manipulate a buffer prior to the first `layer_surface.configure` call must also be treated as errors.

So clearing after `get_layer_surface` would be too late — the error is already committed by then — and the attach itself would be the second half of that sentence. The commit is required too: `attach` alone only sets pending state and would not clear the *current* buffer.

The surface is roleless at that point (the previous role object was destroyed at unmap), so attach+commit is legal, and it is the same sequence GTK performs in `gdk_wayland_surface_hide_surface()`. On a genuinely fresh surface it is a no-op.

## Relationship to #94 and #119

#94 looks like this exact failure — same error, same "random after N opens", reproduces only on the gl/vulkan renderers — and was closed because Hyprland changed rather than because a client-side cause was found. #119 addressed teardown ordering and was declined as a smithay bug. This is a different mechanism: not ordering, and not compositor-side, but persistent `wl_surface` buffer state surviving into a new role object.

## Validation

Hardware: CIX Sky1 (Radxa Orion O6N), labwc/wlroots, GTK4 4.22.4, gtk4-layer-shell 1.3.0, GLES on Mali (libmali).

Tested on metal by isolating the library as the only variable. The client is a shell build that does **not** contain any client-side workaround, so the library is doing all the work:

| boot | shell binary | libgtk4-layer-shell | result |
|---|---|---|---|
| 17:32 | `e23ebc08` (no client-side fix) | stock `55919c08` | crashed immediately on repeated launcher opens |
| 17:35 | `e23ebc08` (identical binary) | patched `0f43ad6d` | repeated launcher opens + workspace pager, no crash |

Same binary, same kernel, same session type, minutes apart. On the patched run the shell process is one second younger than the compositor it was launched by and stayed that way throughout testing, i.e. it never restarted.

For completeness on how the mechanism was originally established: a client-side workaround (dropping the `GdkSurface` on close, so each open gets a fresh `wl_surface`) also eliminates it, and a Wayland trace analyzer that flags a layer surface re-created over a surface still holding a buffer went from 1 dangerous re-creation to 0 across 36 layer surfaces. That workaround is proposed separately downstream, but it has now twice missed close paths that a client has to remember to cover — which is the argument for fixing it here instead, once, for every client.

## Why this may not reproduce on your hardware

A hypothesis, not a claim. The bug needs the animation frame to land inside the window between unmap and the next open, bounded by when `wl_buffer.release` returns. On unified-memory Mali the buffer is the same physical page the compositor samples, dmabuf-imported with no copy, so release can come back almost immediately — hence the ~0.7 ms figure. On a discrete GPU the buffer sits behind an explicit VRAM transfer and that window may never open wide enough to hit.

That would also explain the gl/vulkan-only character in #94 — those are the renderers that still have a live GPU buffer attached at close time — and the "random after N opens" behaviour, since the race window is set by memory topology rather than by anything in the client.

We should be able to test that directly before long: we're bringing this shell up on an 8 GB Dragon Q8B with a GPU, and I'll report back either way. Happy to hold the PR until then if you'd rather see the cross-hardware result first.


---

### Review notes

An earlier revision of this PR placed the clear *after* `get_layer_surface`. That was wrong for the reason quoted above, and an adversarial review pass on our side caught it before it reached you. Corrected in `4920e1b`.

Two other candidate objections from that review, checked and dismissed with evidence:

* **Could the session-lock `wl_surface.attach` hook swallow this null attach?** No. `surface_data` entries are only added inside `if (self)` in `create_xdg_surface_hook`, where `self = callback(wl_surface)` returns a `lock_surface_t*`. A layer surface has none, so it never enters that table.
* **Are `0, 0` offsets correct for `wl_surface` v5+?** Yes — non-zero offsets raise `invalid_offset`; zero is required, and is valid on older versions too.
